### PR TITLE
:wrench: Add frontend/bin/remove_conflicting_devdependencies.sh (fixe…

### DIFF
--- a/frontend/bin/remove_conflicting_devdependencies.sh
+++ b/frontend/bin/remove_conflicting_devdependencies.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Get the directory of the script
+SCRIPT_DIR=`dirname $0`;
+FRONTEND_DIR=`dirname $SCRIPT_DIR`
+
+cd $FRONTEND_DIR;
+
+CONFLICTS=("@maykin-ui/admin-ui/node_modules/react" "@maykin-ui/admin-ui/node_modules/react-dom")
+
+# Function to check if a directory exists
+function directory_exists() {
+  [ -d $1 ]
+}
+
+count=0;
+for dir in ${CONFLICTS[@]}; do
+  fulldir="node_modules/${dir}"
+
+  if directory_exists $fulldir; then
+    echo "removing conflicting dependency: $fulldir"
+    rm -rf $fulldir;
+    let count++
+  else
+    echo "conflicting dependency not found: $fulldir"
+  fi
+done
+
+echo ""
+echo "$count conflicting dependencies removed"
+
+if [ $count -gt 0 ]; then
+  echo "you may need to restart your server"
+fi
+


### PR DESCRIPTION
…s issues when installing @maykin-ui/admin-ui locally)

After installing [@maykin-ui/admin-ui](https://github.com/maykinmedia/admin-ui) using a directory path (`npm install /path/to/admin-ui`) issues may occur caused by a conflict between the upstream `react` and `react-dev` packages and their equivalents installed in admin ui.

This scripts removes those libraries from admin-ui's node_modules to allow a regular development flow.

TODO: If this causes issues on maykin-ui's side we might need to alter the script to replace the libraries in maykin-ui with symlinks to open-acrchiefbeheer.