### PR TITLE
Make read timeout configurable

### DIFF
--- a/backend/src/openarchiefbeheer/conf/base.py
+++ b/backend/src/openarchiefbeheer/conf/base.py
@@ -389,8 +389,9 @@ else:
 
 RELEASE = config("RELEASE", GIT_SHA)
 
+REQUESTS_READ_TIMEOUT = config("REQUESTS_READ_TIMEOUT", 30)
 # Default (connection timeout, read timeout) for the requests library (in seconds)
-REQUESTS_DEFAULT_TIMEOUT = (10, 30)
+REQUESTS_DEFAULT_TIMEOUT = (10, REQUESTS_READ_TIMEOUT)
 
 ##############################
 #                            #


### PR DESCRIPTION
This is useful if open-zaak is very slow. Like in our case... I set this value to 5000 for our test environment and I also use this locally if I want to retrieve the zaken from open zaak