### PR TITLE
:bug: [#169] Let react-router handle routes of single page app

### DIFF
--- a/docker-nginx-default.conf
+++ b/docker-nginx-default.conf
@@ -7,7 +7,7 @@ server {
         proxy_set_header Host $http_host;
     }
 
-    location = / {
+    location / {
         try_files $uri $uri/ /static/frontend/index.html;
     }
 }


### PR DESCRIPTION
Fixes #169 

In the docs of React Router: https://reactrouter.com/en/6.24.1/routers/picking-a-router#web-projects

> If you're hosting your app on a static file server, you'll need to configure it to send all requests to your index.html to avoid getting 404s.

Corresponding change in the chart: https://github.com/maykinmedia/charts/pull/109/commits/a3a597153aed2996f49d1f750f6e75c3cf3e5d21