### PR TITLE
Feature/#95 archivist review

### DIFF
--- a/backend/src/openarchiefbeheer/accounts/api/serializers.py
+++ b/backend/src/openarchiefbeheer/accounts/api/serializers.py
@@ -10,6 +10,7 @@ class RoleSerializer(serializers.ModelSerializer):
             "name",
             "can_start_destruction",
             "can_review_destruction",
+            "can_review_final_list",
             "can_view_case_details",
         )
 

--- a/backend/src/openarchiefbeheer/destruction/api/permissions.py
+++ b/backend/src/openarchiefbeheer/destruction/api/permissions.py
@@ -16,7 +16,10 @@ class CanReviewPermission(permissions.BasePermission):
     message = _("You are not allowed to review a destruction list.")
 
     def has_permission(self, request, view):
-        return request.user.role and request.user.role.can_review_destruction
+        return request.user.role and (
+            request.user.role.can_review_destruction
+            or request.user.role.can_review_final_list
+        )
 
 
 class CanUpdateDestructionList(permissions.BasePermission):

--- a/backend/src/openarchiefbeheer/destruction/api/viewsets.py
+++ b/backend/src/openarchiefbeheer/destruction/api/viewsets.py
@@ -27,6 +27,7 @@ from .filtersets import (
 )
 from .permissions import (
     CanMarkListAsFinal,
+    CanReviewPermission,
     CanStartDestructionPermission,
     CanTriggerDeletion,
     CanUpdateDestructionList,
@@ -277,6 +278,13 @@ class DestructionListReviewViewSet(
     queryset = DestructionListReview.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filterset_class = DestructionListReviewFilterset
+
+    def get_permissions(self):
+        if self.action == "create":
+            permission_classes = [IsAuthenticated & CanReviewPermission]
+        else:
+            permission_classes = [IsAuthenticated]
+        return [permission() for permission in permission_classes]
 
 
 @extend_schema_view(

--- a/backend/src/openarchiefbeheer/destruction/models.py
+++ b/backend/src/openarchiefbeheer/destruction/models.py
@@ -141,7 +141,15 @@ class DestructionList(models.Model):
         reviewers[0].assign()
 
     def assign_next(self) -> None:
+        archivists = (
+            self.assignees.filter(role=ListRole.archivist).order_by("order").last()
+        )
         reviewers = self.assignees.filter(role=ListRole.reviewer).order_by("order")
+
+        if archivists and self.assignee == archivists.user:
+            self.get_author().assign()
+            self.set_status(ListStatus.ready_to_delete)
+            return
 
         # All reviewers have reviewed the draft destruction list
         if self.assignee == reviewers.last().user:

--- a/backend/src/openarchiefbeheer/destruction/models.py
+++ b/backend/src/openarchiefbeheer/destruction/models.py
@@ -145,7 +145,7 @@ class DestructionList(models.Model):
 
         # All reviewers have reviewed the draft destruction list
         last_reviewer = reviewers.last()
-        if last_reviewer and self.assignee == reviewers.last().user:
+        if last_reviewer and self.assignee == last_reviewer.user:
             self.get_author().assign()
             status = (
                 ListStatus.ready_to_delete

--- a/backend/src/openarchiefbeheer/destruction/models.py
+++ b/backend/src/openarchiefbeheer/destruction/models.py
@@ -155,15 +155,12 @@ class DestructionList(models.Model):
             self.set_status(status)
             return
 
-        # Check if archivist has approved the list.
-        try:
-            archivist = self.assignees.get(role=ListRole.archivist)
-            if archivist and self.assignee == archivist.user:
-                self.get_author().assign()
-                self.set_status(ListStatus.ready_to_delete)
-                return
-        except DestructionListAssignee.DoesNotExist:
-            pass
+        # Archivist has approved the (now final) list.
+        current_assignee = self.assignees.get(user=self.assignee)
+        if current_assignee.role == ListRole.archivist:
+            self.get_author().assign()
+            self.set_status(ListStatus.ready_to_delete)
+            return
 
         # Assign (next) reviewer
         current_assignee = self.assignees.get(user=self.assignee)

--- a/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
@@ -889,7 +889,7 @@ class DestructionListReviewViewSetTest(APITestCase):
             2,
         )
 
-    def test_create_review_archivist(self):
+    def test_create_review_archivist_accepted(self):
         archivist = UserFactory.create(
             username="archivaris",
             email="archivaris@oab.nl",

--- a/backend/src/openarchiefbeheer/destruction/tests/test_models.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_models.py
@@ -296,15 +296,7 @@ class DestructionListTest(TestCase):
         destruction_list = DestructionListFactory.create(
             assignee=archivist, status=ListStatus.ready_for_archivist
         )
-        zaken = ZaakFactory.create_batch(
-            2, zaaktype="http://catalogi-api.nl/zaaktype/1"
-        )
-        DestructionListItemFactory.create(
-            destruction_list=destruction_list, zaak=zaken[0].url
-        )
-        DestructionListItemFactory.create(
-            destruction_list=destruction_list, zaak=zaken[1].url
-        )
+        DestructionListItemFactory.create_batch(2, destruction_list=destruction_list)
         DestructionListAssigneeFactory.create(
             user=destruction_list.author,
             role=ListRole.author,

--- a/backend/src/openarchiefbeheer/destruction/tests/test_models.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_models.py
@@ -321,14 +321,7 @@ class DestructionListTest(TestCase):
             destruction_list=destruction_list,
         )
 
-        with patch(
-            "openarchiefbeheer.destruction.models.ArchiveConfig.get_solo",
-            return_value=ArchiveConfig(
-                zaaktypes_short_process=["http://catalogi-api.nl/zaaktype/2"]
-            ),
-        ):
-            destruction_list.assign_next()
-
+        destruction_list.assign_next()
         destruction_list.refresh_from_db()
 
         self.assertEqual(destruction_list.status, ListStatus.ready_to_delete)

--- a/backend/src/openarchiefbeheer/destruction/tests/test_serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_serializers.py
@@ -445,7 +445,6 @@ class DestructionListSerializerTests(TestCase):
 
 
 class DestructionListReviewSerializerTests(TestCase):
-    @override_settings(LANGUAGE_CODE="en")
     def test_if_user_not_assigned_cannot_create_review(self):
         reviewer1 = UserFactory.create(
             username="reviewer1",

--- a/backend/src/openarchiefbeheer/destruction/tests/test_serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_serializers.py
@@ -487,7 +487,9 @@ class DestructionListReviewSerializerTests(TestCase):
             role__can_review_destruction=True,
             role__can_review_final_list=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=user, status=ListStatus.changes_requested)
+        destruction_list = DestructionListFactory.create(
+            assignee=user, status=ListStatus.changes_requested
+        )
 
         data = {
             "destruction_list": destruction_list.uuid,
@@ -503,7 +505,9 @@ class DestructionListReviewSerializerTests(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors["author"][0],
-            _("The status of this destruction list prevents you from creating a review at this stage."),
+            _(
+                "The status of this destruction list prevents you from creating a review at this stage."
+            ),
         )
 
     @override_settings(LANGUAGE_CODE="en")
@@ -513,7 +517,9 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer1@oab.nl",
             role__can_review_destruction=False,
         )
-        destruction_list = DestructionListFactory.create(assignee=user, status=ListStatus.ready_to_review)
+        destruction_list = DestructionListFactory.create(
+            assignee=user, status=ListStatus.ready_to_review
+        )
 
         data = {
             "destruction_list": destruction_list.uuid,
@@ -529,7 +535,9 @@ class DestructionListReviewSerializerTests(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors["author"][0],
-            _("The status of this destruction list prevents you from creating a review at this stage."),
+            _(
+                "The status of this destruction list prevents you from creating a review at this stage."
+            ),
         )
 
     @override_settings(LANGUAGE_CODE="en")
@@ -539,7 +547,9 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer1@oab.nl",
             role__can_review_final_list=False,
         )
-        destruction_list = DestructionListFactory.create(assignee=user, status=ListStatus.ready_for_archivist)
+        destruction_list = DestructionListFactory.create(
+            assignee=user, status=ListStatus.ready_for_archivist
+        )
 
         data = {
             "destruction_list": destruction_list.uuid,
@@ -555,7 +565,9 @@ class DestructionListReviewSerializerTests(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertEqual(
             serializer.errors["author"][0],
-            _("The status of this destruction list prevents you from creating a review at this stage."),
+            _(
+                "The status of this destruction list prevents you from creating a review at this stage."
+            ),
         )
 
     @override_settings(LANGUAGE_CODE="en")
@@ -646,8 +658,9 @@ class DestructionListReviewSerializerTests(TestCase):
             role__can_review_destruction=True,
         )
         destruction_list = DestructionListFactory.create(
-            assignee=reviewer, author__email="record_manager@oab.nl",
-            status=ListStatus.ready_to_review
+            assignee=reviewer,
+            author__email="record_manager@oab.nl",
+            status=ListStatus.ready_to_review,
         )
         DestructionListAssigneeFactory.create(
             user=destruction_list.author,
@@ -703,8 +716,9 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer@oab.nl",
             role__can_review_destruction=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=reviewer,
-            status=ListStatus.ready_to_review)
+        destruction_list = DestructionListFactory.create(
+            assignee=reviewer, status=ListStatus.ready_to_review
+        )
         item = DestructionListItemFactory.create(destruction_list=destruction_list)
 
         data = {
@@ -737,8 +751,9 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer@oab.nl",
             role__can_review_destruction=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=reviewer,
-            status=ListStatus.ready_to_review)
+        destruction_list = DestructionListFactory.create(
+            assignee=reviewer, status=ListStatus.ready_to_review
+        )
 
         data = {
             "destruction_list": destruction_list.uuid,
@@ -765,8 +780,7 @@ class DestructionListReviewSerializerTests(TestCase):
             role__can_review_destruction=True,
         )
         destruction_list = DestructionListFactory.create(
-            assignee=reviewer, name="Test list",
-            status=ListStatus.ready_to_review
+            assignee=reviewer, name="Test list", status=ListStatus.ready_to_review
         )
         items = DestructionListItemFactory.create_batch(
             3, destruction_list=destruction_list
@@ -828,8 +842,9 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer@oab.nl",
             role__can_review_destruction=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=reviewer,
-            status=ListStatus.ready_to_review)
+        destruction_list = DestructionListFactory.create(
+            assignee=reviewer, status=ListStatus.ready_to_review
+        )
         # Not part of the destruction list
         item = DestructionListItemFactory.create(status=ListItemStatus.suggested)
 
@@ -865,8 +880,9 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer@oab.nl",
             role__can_review_destruction=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=reviewer,
-            status=ListStatus.ready_to_review)
+        destruction_list = DestructionListFactory.create(
+            assignee=reviewer, status=ListStatus.ready_to_review
+        )
         item = DestructionListItemFactory.create(
             status=ListItemStatus.removed, destruction_list=destruction_list
         )

--- a/backend/src/openarchiefbeheer/destruction/tests/test_serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_serializers.py
@@ -445,6 +445,7 @@ class DestructionListSerializerTests(TestCase):
 
 
 class DestructionListReviewSerializerTests(TestCase):
+    @override_settings(LANGUAGE_CODE="en")
     def test_if_user_not_assigned_cannot_create_review(self):
         reviewer1 = UserFactory.create(
             username="reviewer1",
@@ -476,6 +477,85 @@ class DestructionListReviewSerializerTests(TestCase):
                 "This user is not currently assigned to the destruction list, "
                 "so they cannot create a review at this stage."
             ),
+        )
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_if_list_in_wrong_status_cannot_be_reviewed(self):
+        user = UserFactory.create(
+            username="reviewer1",
+            email="reviewer1@oab.nl",
+            role__can_review_destruction=True,
+            role__can_review_final_list=True,
+        )
+        destruction_list = DestructionListFactory.create(assignee=user, status=ListStatus.changes_requested)
+
+        data = {
+            "destruction_list": destruction_list.uuid,
+            "decision": ReviewDecisionChoices.accepted,
+        }
+        request = factory.get("/foo")
+        request.user = user
+
+        serializer = DestructionListReviewSerializer(
+            data=data, context={"request": request}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["author"][0],
+            _("The status of this destruction list prevents you from creating a review at this stage."),
+        )
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_if_user_not_a_reviewer_cannot_create_review(self):
+        user = UserFactory.create(
+            username="reviewer1",
+            email="reviewer1@oab.nl",
+            role__can_review_destruction=False,
+        )
+        destruction_list = DestructionListFactory.create(assignee=user, status=ListStatus.ready_to_review)
+
+        data = {
+            "destruction_list": destruction_list.uuid,
+            "decision": ReviewDecisionChoices.accepted,
+        }
+        request = factory.get("/foo")
+        request.user = user
+
+        serializer = DestructionListReviewSerializer(
+            data=data, context={"request": request}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["author"][0],
+            _("The status of this destruction list prevents you from creating a review at this stage."),
+        )
+
+    @override_settings(LANGUAGE_CODE="en")
+    def test_if_user_not_an_archivist_cannot_create_review(self):
+        user = UserFactory.create(
+            username="reviewer1",
+            email="reviewer1@oab.nl",
+            role__can_review_final_list=False,
+        )
+        destruction_list = DestructionListFactory.create(assignee=user, status=ListStatus.ready_for_archivist)
+
+        data = {
+            "destruction_list": destruction_list.uuid,
+            "decision": ReviewDecisionChoices.accepted,
+        }
+        request = factory.get("/foo")
+        request.user = user
+
+        serializer = DestructionListReviewSerializer(
+            data=data, context={"request": request}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["author"][0],
+            _("The status of this destruction list prevents you from creating a review at this stage."),
         )
 
     @override_settings(LANGUAGE_CODE="en")
@@ -566,7 +646,8 @@ class DestructionListReviewSerializerTests(TestCase):
             role__can_review_destruction=True,
         )
         destruction_list = DestructionListFactory.create(
-            assignee=reviewer, author__email="record_manager@oab.nl"
+            assignee=reviewer, author__email="record_manager@oab.nl",
+            status=ListStatus.ready_to_review
         )
         DestructionListAssigneeFactory.create(
             user=destruction_list.author,
@@ -622,7 +703,8 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer@oab.nl",
             role__can_review_destruction=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=reviewer)
+        destruction_list = DestructionListFactory.create(assignee=reviewer,
+            status=ListStatus.ready_to_review)
         item = DestructionListItemFactory.create(destruction_list=destruction_list)
 
         data = {
@@ -655,7 +737,8 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer@oab.nl",
             role__can_review_destruction=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=reviewer)
+        destruction_list = DestructionListFactory.create(assignee=reviewer,
+            status=ListStatus.ready_to_review)
 
         data = {
             "destruction_list": destruction_list.uuid,
@@ -682,7 +765,8 @@ class DestructionListReviewSerializerTests(TestCase):
             role__can_review_destruction=True,
         )
         destruction_list = DestructionListFactory.create(
-            assignee=reviewer, name="Test list"
+            assignee=reviewer, name="Test list",
+            status=ListStatus.ready_to_review
         )
         items = DestructionListItemFactory.create_batch(
             3, destruction_list=destruction_list
@@ -744,7 +828,8 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer@oab.nl",
             role__can_review_destruction=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=reviewer)
+        destruction_list = DestructionListFactory.create(assignee=reviewer,
+            status=ListStatus.ready_to_review)
         # Not part of the destruction list
         item = DestructionListItemFactory.create(status=ListItemStatus.suggested)
 
@@ -780,7 +865,8 @@ class DestructionListReviewSerializerTests(TestCase):
             email="reviewer@oab.nl",
             role__can_review_destruction=True,
         )
-        destruction_list = DestructionListFactory.create(assignee=reviewer)
+        destruction_list = DestructionListFactory.create(assignee=reviewer,
+            status=ListStatus.ready_to_review)
         item = DestructionListItemFactory.create(
             status=ListItemStatus.removed, destruction_list=destruction_list
         )

--- a/frontend/src/fixtures/user.ts
+++ b/frontend/src/fixtures/user.ts
@@ -1,5 +1,14 @@
-import { User } from "../lib/api/auth";
+import { Role, User } from "../lib/api/auth";
 import { createArrayFactory, createObjectFactory } from "./factory";
+
+const FIXTURE_ROLE = {
+  name: "Test Role",
+  canStartDestruction: false,
+  canReviewDestruction: false,
+  canReviewFinalList: false,
+  canViewCaseDetails: true,
+};
+export const roleFactory = createObjectFactory<Role>(FIXTURE_ROLE);
 
 const FIXTURE_USER: User = {
   pk: 1,
@@ -7,12 +16,7 @@ const FIXTURE_USER: User = {
   firstName: "Test",
   lastName: "User",
   email: "user@example.com",
-  role: {
-    name: "Test Role",
-    canStartDestruction: false,
-    canReviewDestruction: false,
-    canViewCaseDetails: true,
-  },
+  role: roleFactory(),
 };
 
 const FIXTURE_RECORD_MANAGER: User = {
@@ -25,6 +29,7 @@ const FIXTURE_RECORD_MANAGER: User = {
     name: "recordmanager",
     canStartDestruction: true,
     canReviewDestruction: false,
+    canReviewFinalList: false,
     canViewCaseDetails: false,
   },
 };
@@ -39,6 +44,7 @@ const FIXTURE_BEOORDELAAR: User = {
     name: "beoordelaar",
     canStartDestruction: false,
     canReviewDestruction: true,
+    canReviewFinalList: false,
     canViewCaseDetails: false,
   },
 };
@@ -53,6 +59,7 @@ const FIXTURE_PROCES_EIGENAAR: User = {
     name: "proceseigenaar",
     canStartDestruction: false,
     canReviewDestruction: true,
+    canReviewFinalList: false,
     canViewCaseDetails: false,
   },
 };

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -14,6 +14,7 @@ export type Role = {
   name: string;
   canStartDestruction: boolean;
   canReviewDestruction: boolean;
+  canReviewFinalList: boolean;
   canViewCaseDetails: boolean;
 };
 

--- a/frontend/src/lib/auth/permissions.ts
+++ b/frontend/src/lib/auth/permissions.ts
@@ -22,7 +22,7 @@ export function canReviewDestructionList(
   user: User,
   destructionList: DestructionList,
 ) {
-  if (!user.role.canReviewDestruction) {
+  if (!(user.role.canReviewDestruction || user.role.canReviewFinalList)) {
     return false;
   }
 

--- a/frontend/src/pages/destructionlist/detail/components/DestructionListAssignees/DestructionListAssignees.tsx
+++ b/frontend/src/pages/destructionlist/detail/components/DestructionListAssignees/DestructionListAssignees.tsx
@@ -41,13 +41,15 @@ export function DestructionListAssignees({
     open: false,
   });
 
-  const fields = reviewerAssignees.map((_, i) => ({
-    name: `reviewer_${i + 1}`,
-    type: "string",
-    options: reviewers.map((user) => ({
-      label: formatUser(user),
-    })),
-  }));
+  const fields = reviewerAssignees
+    .filter((r) => r.user.role.canReviewDestruction)
+    .map((_, i) => ({
+      name: `reviewer_${i + 1}`,
+      type: "string",
+      options: reviewers.map((user) => ({
+        label: formatUser(user),
+      })),
+    }));
 
   const labeledObject = reviewerAssignees.reduce(
     (acc, val, i) => ({

--- a/frontend/src/pages/destructionlist/detail/components/DestructionListToolbar/DestructionListToolbar.tsx
+++ b/frontend/src/pages/destructionlist/detail/components/DestructionListToolbar/DestructionListToolbar.tsx
@@ -87,7 +87,7 @@ export function DestructionListToolbar({
             <AttributeTable
               object={{
                 "Laatste review door":
-                  review.author && formatUser(review.author),
+                  review.author && formatUser(review.author, true),
                 Opmerking: review.listFeedback,
                 Beoordeling: (
                   <Badge level={REVIEW_DECISION_LEVEL_MAPPING[review.decision]}>

--- a/frontend/src/pages/destructionlist/detail/constants.ts
+++ b/frontend/src/pages/destructionlist/detail/constants.ts
@@ -1,6 +1,9 @@
 import { BadgeProps } from "@maykin-ui/admin-ui";
 
-import { DestructionListStatus } from "../../../lib/api/destructionLists";
+import {
+  DESTRUCTION_LIST_STATUSES,
+  DestructionListStatus,
+} from "../../../lib/api/destructionLists";
 import { Review } from "../../../lib/api/review";
 
 export const REVIEW_DECISION_MAPPING: Record<Review["decision"], string> = {
@@ -18,7 +21,8 @@ export const REVIEW_DECISION_LEVEL_MAPPING: Record<
 
 export const STATUSES_ELIGIBLE_FOR_EDIT = ["changes_requested"];
 export const STATUSES_ELIGABLE_FOR_REASSIGNMENT = ["internally_reviewed"];
-export const STATUSES_ELIGIBLE_FOR_REVIEW = ["ready_to_review"];
+export const STATUSES_ELIGIBLE_FOR_REVIEW: (typeof DESTRUCTION_LIST_STATUSES)[number][] =
+  ["ready_to_review", "ready_for_archivist"];
 
 export const STATUS_MAPPING: { [key in DestructionListStatus]: string } = {
   changes_requested: "Wijzigingen aangevraagd",

--- a/frontend/src/pages/landing/Landing.tsx
+++ b/frontend/src/pages/landing/Landing.tsx
@@ -90,6 +90,7 @@ export const Landing = () => {
           : undefined;
 
       case "ready_to_review":
+      case "ready_for_archivist":
         return canReviewDestructionList(user, list)
           ? `/destruction-lists/${list.uuid}/review`
           : undefined;

--- a/frontend/src/pages/login/Login.action.tsx
+++ b/frontend/src/pages/login/Login.action.tsx
@@ -1,7 +1,8 @@
 import { ActionFunctionArgs } from "@remix-run/router/utils";
 import { redirect } from "react-router-dom";
 
-import { login, logout } from "../../lib/api/auth";
+import { login } from "../../lib/api/auth";
+import { cacheDelete } from "../../lib/cache/cache";
 import "./Login.css";
 
 /**
@@ -14,7 +15,7 @@ export async function loginAction({ request }: ActionFunctionArgs) {
   const password = formData.get("password");
 
   try {
-    await logout();
+    await cacheDelete("whoAmI");
     await login(username as string, password as string);
     const url = new URL(request.url);
     const next = url.searchParams.get("next") || "/";

--- a/frontend/src/pages/login/Login.tsx
+++ b/frontend/src/pages/login/Login.tsx
@@ -1,4 +1,4 @@
-import { AttributeData, LoginTemplate } from "@maykin-ui/admin-ui";
+import { AttributeData, LoginTemplate, forceArray } from "@maykin-ui/admin-ui";
 import { useActionData, useSubmit } from "react-router-dom";
 
 import "./Login.css";
@@ -31,15 +31,18 @@ export function LoginPage({ ...props }: LoginProps) {
   const submit = useSubmit();
 
   const formErrors = Object.fromEntries(
-    Object.entries(actionData).map(([key, values]) => [key, values.join(", ")]),
+    Object.entries(actionData).map(([key, values]) => [
+      key,
+      forceArray(values)?.join(", "),
+    ]),
   );
-  const { nonFieldErrors, ...errors } = formErrors;
+  const { detail, nonFieldErrors, ...errors } = formErrors;
 
   return (
     <LoginTemplate
-      slotPrimaryNavigation={<></>} // FIXME: Shoudl be easier to override
+      slotPrimaryNavigation={<></>} // FIXME: Should be easier to override
       formProps={{
-        nonFieldErrors,
+        nonFieldErrors: nonFieldErrors || detail,
         errors,
         fields,
         onSubmit: (_, data) =>


### PR DESCRIPTION
Part of #95 implements review flow for archivist.

I'm not too sure yet about the permissions `CanReviewPermission` for the archivist. As far as I know the archivist is mostly the same as a reviewer but still: it uses a different role.

Maybe we should implement a `has_object_permission` for usage with a destruction list. The permission can be returned based on the combination of the destruction list status and the role of the user.

If we make a change to `CanReviewPermission` the frontend counterpart `canReviewDestructionList` should be updated as well.