### PR TITLE
[#181] Update backend to run on port 8000 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           npm ci --legacy-peer-deps
           CI=false npm run build 
         env: 
-          REACT_APP_API_URL: "http://localhost:8080"
+          REACT_APP_API_URL: "http://localhost:8000"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,5 +112,5 @@ LABEL org.label-schema.vcs-ref=$COMMIT_HASH \
 RUN python src/manage.py collectstatic --noinput \
     && python src/manage.py compilemessages
 
-EXPOSE 8080
+EXPOSE 8000
 CMD ["/start.sh"]

--- a/backend/bin/docker_start.sh
+++ b/backend/bin/docker_start.sh
@@ -9,7 +9,7 @@ export PGPORT=${DB_PORT:-5432}
 
 fixtures_dir=${FIXTURES_DIR:-/app/fixtures}
 
-uwsgi_port=${UWSGI_PORT:-8080}
+uwsgi_port=${UWSGI_PORT:-8000}
 uwsgi_processes=${UWSGI_PROCESSES:-4}
 uwsgi_threads=${UWSGI_THREADS:-1}
 

--- a/backend/dotenv.dev.example
+++ b/backend/dotenv.dev.example
@@ -1,7 +1,7 @@
 DISABLE_2FA=yes
 
 ALLOWED_HOSTS=localhost
-CORS_ALLOWED_ORIGINS=http://localhost:8080,http://localhost:3000
+CORS_ALLOWED_ORIGINS=http://localhost:8000,http://localhost:3000
 CSRF_TRUSTED_ORIGINS=http://localhost:3000
 CSRF_COOKIE_SAMESITE='None'
 CSRF_COOKIE_SECURE=False

--- a/backend/src/openarchiefbeheer/conf/ci.py
+++ b/backend/src/openarchiefbeheer/conf/ci.py
@@ -20,7 +20,7 @@ PLAYWRIGHT_TRACE_PATH = config("PLAYWRIGHT_TRACE_PATH", default="playwright-trac
 from .base import *  # noqa isort:skip
 
 # End-to-end test settings
-E2E_PORT = config("E2E_PORT", default=8080)
+E2E_PORT = config("E2E_PORT", default=8000)
 E2E_SERVE_FRONTEND = config("E2E_SERVE_FRONTEND", default=False)
 
 CACHES.update(

--- a/backend/src/openarchiefbeheer/conf/dev.py
+++ b/backend/src/openarchiefbeheer/conf/dev.py
@@ -95,7 +95,7 @@ warnings.filterwarnings(
 )
 
 # End-to-end test settings
-E2E_PORT = config("E2E_PORT", default=8080)
+E2E_PORT = config("E2E_PORT", default=8000)
 E2E_SERVE_FRONTEND = config("E2E_SERVE_FRONTEND", default=False)
 
 # Playwright settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,8 @@ services:
       - DB_HOST=db
       - CACHE_DEFAULT=redis:6379/0
       - CACHE_AXES=redis:6379/0
-      - CORS_ALLOWED_ORIGINS=http://localhost:9000,http://localhost:8080
-      - CSRF_TRUSTED_ORIGINS=http://localhost:9000,http://localhost:8080
+      - CORS_ALLOWED_ORIGINS=http://localhost:9000,http://localhost:8000
+      - CSRF_TRUSTED_ORIGINS=http://localhost:9000,http://localhost:8000
       - CSRF_COOKIE_SAMESITE=none
       - CSRF_COOKIE_SECURE=False
       - SESSION_COOKIE_SAMESITE=none
@@ -44,11 +44,11 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
       - CELERY_LOGLEVEL=DEBUG
-      - REACT_APP_API_URL=http://localhost:8080
+      - REACT_APP_API_URL=http://localhost:8000
       - REACT_APP_API_PATH=/api/v1
       - REACT_APP_ZAAK_URL_TEMPLATE=https://www.example.com/zaken/{identificatie}
     ports:
-      - 8080:8080
+      - 8000:8000
     depends_on:
       - db
       - redis

--- a/docker-nginx-default.conf
+++ b/docker-nginx-default.conf
@@ -3,7 +3,7 @@ server {
     server_name  localhost;
 
     location ~ ^/admin|static|assets|api/ {
-        proxy_pass http://web:8080;
+        proxy_pass http://web:8000;
         proxy_set_header Host $http_host;
     }
 


### PR DESCRIPTION
Partly Fixes #181

The public role of the ansible playbook expects the docker container to expose port 8000.

I think it is also better to be consistent with all the other apps