### PR TITLE
[#383] Fix _zaak_url not populated

### DIFF
--- a/backend/src/openarchiefbeheer/destruction/models.py
+++ b/backend/src/openarchiefbeheer/destruction/models.py
@@ -125,7 +125,12 @@ class DestructionList(models.Model):
 
     def add_items(self, zaken: Iterable["Zaak"]) -> list["DestructionListItem"]:
         return DestructionListItem.objects.bulk_create(
-            [DestructionListItem(destruction_list=self, zaak=zaak) for zaak in zaken]
+            [
+                DestructionListItem(
+                    destruction_list=self, zaak=zaak, _zaak_url=zaak.url
+                )
+                for zaak in zaken
+            ]
         )
 
     def get_author(self) -> "DestructionListAssignee":

--- a/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
@@ -120,6 +120,12 @@ class DestructionListViewSetTest(APITestCase):
         self.assertEqual(
             items[1].zaak.url, "http://localhost:8003/zaken/api/v1/zaken/222-222-222"
         )
+        self.assertEqual(
+            items[0]._zaak_url, "http://localhost:8003/zaken/api/v1/zaken/111-111-111"
+        )
+        self.assertEqual(
+            items[1]._zaak_url, "http://localhost:8003/zaken/api/v1/zaken/222-222-222"
+        )
 
         self.assertEqual(destruction_list.author, record_manager)
 


### PR DESCRIPTION
Fixes #383 

I didn't add a migration to repopulate the _zaak_url for the cases that don't have it because we already have a migration that does this (0020_auto_20240822_1113.py). I rerun this migration on the test environment.