### PR TITLE
Issue/edit refactor

### DIFF
--- a/backend/src/openarchiefbeheer/destruction/api/serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/api/serializers.py
@@ -267,9 +267,9 @@ class DestructionListWriteSerializer(serializers.ModelSerializer):
     ) -> DestructionList:
         user = self.context["request"].user
         validated_data.pop("reviewer", None)
-        add_data = validated_data.pop("add", None)
-        remove_data = validated_data.pop("remove", None)
-        items_data = validated_data.pop("items", None)
+        add_data = validated_data.pop("add", [])
+        remove_data = validated_data.pop("remove", [])
+        items_data = validated_data.pop("items", [])
         instance.contains_sensitive_info = validated_data.pop(
             "contains_sensitive_info", instance.contains_sensitive_info
         )
@@ -278,7 +278,7 @@ class DestructionListWriteSerializer(serializers.ModelSerializer):
 
         instance.name = validated_data.pop("name", instance.name)
 
-        if items_data is not None or bulk_select:
+        if items_data or bulk_select:
             instance.items.all().delete()
 
             zaken = self._get_zaken(zaak_filters, items_data, bulk_select)
@@ -286,7 +286,7 @@ class DestructionListWriteSerializer(serializers.ModelSerializer):
             instance.add_items(zaken)
 
         if add_data:
-            zaken = self._get_zaken(zaak_filters, add_data or [], bulk_select)
+            zaken = self._get_zaken(zaak_filters, add_data, bulk_select)
             self.instance.add_items(zaken)
 
         if remove_data:

--- a/backend/src/openarchiefbeheer/destruction/api/serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/api/serializers.py
@@ -149,8 +149,10 @@ class DestructionListItemReadSerializer(serializers.ModelSerializer):
 
 
 class DestructionListWriteSerializer(serializers.ModelSerializer):
-    reviewer = ReviewerAssigneeSerializer(required=False)
+    add = DestructionListItemWriteSerializer(many=True, required=False)
+    remove = DestructionListItemWriteSerializer(many=True, required=False)
     items = DestructionListItemWriteSerializer(many=True, required=False)
+    reviewer = ReviewerAssigneeSerializer(required=False)
     author = UserSerializer(read_only=True)
     select_all = serializers.BooleanField(
         required=False,
@@ -168,12 +170,14 @@ class DestructionListWriteSerializer(serializers.ModelSerializer):
     class Meta:
         model = DestructionList
         fields = (
+            "add",
+            "remove",
+            "items",
             "uuid",
             "name",
             "author",
             "contains_sensitive_info",
             "reviewer",
-            "items",
             "status",
             "select_all",
             "zaak_filters",
@@ -263,6 +267,8 @@ class DestructionListWriteSerializer(serializers.ModelSerializer):
     ) -> DestructionList:
         user = self.context["request"].user
         validated_data.pop("reviewer", None)
+        add_data = validated_data.pop("add", None)
+        remove_data = validated_data.pop("remove", None)
         items_data = validated_data.pop("items", None)
         instance.contains_sensitive_info = validated_data.pop(
             "contains_sensitive_info", instance.contains_sensitive_info
@@ -278,6 +284,14 @@ class DestructionListWriteSerializer(serializers.ModelSerializer):
             zaken = self._get_zaken(zaak_filters, items_data, bulk_select)
 
             instance.add_items(zaken)
+
+        if add_data:
+            zaken = self._get_zaken(zaak_filters, add_data or [], bulk_select)
+            self.instance.add_items(zaken)
+
+        if remove_data:
+            zaken = self._get_zaken(zaak_filters, remove_data or [], bulk_select)
+            self.instance.remove_items(zaken)
 
         instance.save()
 

--- a/backend/src/openarchiefbeheer/destruction/api/viewsets.py
+++ b/backend/src/openarchiefbeheer/destruction/api/viewsets.py
@@ -112,7 +112,27 @@ from .serializers import (
         ),
         examples=[
             OpenApiExample(
-                name="Example list update",
+                name="Add/remove items",
+                request_only=True,
+                value={
+                    "name": "An example updated list",
+                    "containsSensitiveInfo": False,
+                    "add": [
+                        {
+                            "zaak": "http://some-zaken-api.nl/zaken/api/v1/zaken/111-111-111",
+                            "extraZaakData": {},
+                        },
+                    ],
+                    "remove": [
+                        {
+                            "zaak": "http://some-zaken-api.nl/zaken/api/v1/zaken/222-222-222",
+                            "extraZaakData": {},
+                        },
+                    ],
+                },
+            ),
+            OpenApiExample(
+                name="Replace items",
                 request_only=True,
                 value={
                     "name": "An example updated list",
@@ -128,7 +148,7 @@ from .serializers import (
                         },
                     ],
                 },
-            )
+            ),
         ],
     ),
     partial_update=extend_schema(

--- a/backend/src/openarchiefbeheer/destruction/api/viewsets.py
+++ b/backend/src/openarchiefbeheer/destruction/api/viewsets.py
@@ -88,7 +88,7 @@ from .serializers import (
                             "user": 2,
                         },
                     ],
-                    "items": [
+                    "add": [
                         {
                             "zaak": "http://some-zaken-api.nl/zaken/api/v1/zaken/111-111-111",
                             "extraZaakData": {},
@@ -124,24 +124,6 @@ from .serializers import (
                         },
                     ],
                     "remove": [
-                        {
-                            "zaak": "http://some-zaken-api.nl/zaken/api/v1/zaken/222-222-222",
-                            "extraZaakData": {},
-                        },
-                    ],
-                },
-            ),
-            OpenApiExample(
-                name="Replace items",
-                request_only=True,
-                value={
-                    "name": "An example updated list",
-                    "containsSensitiveInfo": False,
-                    "items": [
-                        {
-                            "zaak": "http://some-zaken-api.nl/zaken/api/v1/zaken/111-111-111",
-                            "extraZaakData": {},
-                        },
                         {
                             "zaak": "http://some-zaken-api.nl/zaken/api/v1/zaken/222-222-222",
                             "extraZaakData": {},

--- a/backend/src/openarchiefbeheer/destruction/models.py
+++ b/backend/src/openarchiefbeheer/destruction/models.py
@@ -157,6 +157,9 @@ class DestructionList(models.Model):
             ]
         )
 
+    def remove_items(self, zaken: Iterable["Zaak"]) -> tuple[int, dict[str, int]]:
+        return self.items.filter(zaak__in=zaken).delete()
+
     def get_author(self) -> "DestructionListAssignee":
         return self.assignees.get(role=ListRole.author)
 

--- a/backend/src/openarchiefbeheer/destruction/models.py
+++ b/backend/src/openarchiefbeheer/destruction/models.py
@@ -147,14 +147,17 @@ class DestructionList(models.Model):
         self.status_changed = timezone.now()
         self.save()
 
-    def add_items(self, zaken: Iterable["Zaak"]) -> list["DestructionListItem"]:
+    def add_items(
+        self, zaken: Iterable["Zaak"], ignore_conflicts: bool = False
+    ) -> list["DestructionListItem"]:
         return DestructionListItem.objects.bulk_create(
             [
                 DestructionListItem(
                     destruction_list=self, zaak=zaak, _zaak_url=zaak.url
                 )
                 for zaak in zaken
-            ]
+            ],
+            ignore_conflicts=ignore_conflicts,
         )
 
     def remove_items(self, zaken: Iterable["Zaak"]) -> tuple[int, dict[str, int]]:

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_create.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_create.py
@@ -62,9 +62,7 @@ class FeatureListCreateTests(GherkinLikeTestCase):
 
             await self.when.reviewer_logs_in(page)
             await self.then.path_should_be(page, "/destruction-lists")
-
-            await self.when.user_clicks_button(page, "Vernietigingslijst opstellen")
-            await self.then.path_should_be(page, "/login?next=/destruction-lists/create")
+            await self.then.not_.page_should_contain_text(page, "Vernietigingslijst opstellen")
 
     async def test_scenario_archivist_cannot_create_list(self):
         async with browser_page() as page:
@@ -73,9 +71,7 @@ class FeatureListCreateTests(GherkinLikeTestCase):
 
             await self.when.archivist_logs_in(page)
             await self.then.path_should_be(page, "/destruction-lists")
-
-            await self.when.user_clicks_button(page, "Vernietigingslijst opstellen")
-            await self.then.path_should_be(page, "/login?next=/destruction-lists/create")
+            await self.then.not_.page_should_contain_text(page, "Vernietigingslijst opstellen")
 
     async def test_zaaktype_filters_on_create_page(self):
            

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_destroy.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_destroy.py
@@ -8,7 +8,7 @@ from ....constants import ListStatus
 
 
 @tag("e2e")
-class FeatureListCreateTests(GherkinLikeTestCase):
+class FeatureListDestroyTests(GherkinLikeTestCase):
     async def test_scenario_record_manager_destroys_list(self):
         async with browser_page() as page:
             await self.given.record_manager_exists()

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_edit.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_edit.py
@@ -6,7 +6,7 @@ from openarchiefbeheer.utils.tests.gherkin import GherkinLikeTestCase
 
 
 @tag("e2e")
-class Issue420EditDestructionList(GherkinLikeTestCase):
+class FeatureListEditTests(GherkinLikeTestCase):
     async def test_scenario_user_edits_multi_page_destruction_list(self):
         async with browser_page() as page:
             await self.given.record_manager_exists()
@@ -40,10 +40,37 @@ class Issue420EditDestructionList(GherkinLikeTestCase):
             await self.then.path_should_be(page, f"/destruction-lists/{str(destruction_list.uuid)}?page=2")
             await self.then.page_should_contain_text(page, "ZAAK-200")
 
-            # Edit destruction list
+            # Add "ZAAK-100"
             await self.when.user_clicks_button(page, "Bewerken", 1)
             await self.then.path_should_be(page, f"/destruction-lists/{str(destruction_list.uuid)}?page=1&is_editing=true")
+
             await self.when.user_clicks_button(page, "2")
             await self.then.path_should_be(page, f"/destruction-lists/{str(destruction_list.uuid)}?page=2&is_editing=true")
             await self.then.zaak_should_be_selected(page, "ZAAK-200")
             await self.then.not_.zaak_should_be_selected(page, "ZAAK-100")  # First unselected zaak
+
+            await self.when.user_selects_zaak(page, "ZAAK-100")
+            await self.when.user_clicks_button(page, "Vernietigingslijst aanpassen")
+            await self.then.path_should_be(page, f"/destruction-lists/{str(destruction_list.uuid)}")
+
+            # View updated destruction list
+            await self.when.user_clicks_button(page, "2")
+            await self.then.page_should_contain_text(page, "ZAAK-100")
+
+            # Remove "ZAAK-100"
+            await self.when.user_clicks_button(page, "Bewerken", 1)
+            await self.then.path_should_be(page, f"/destruction-lists/{str(destruction_list.uuid)}?page=1&is_editing=true")
+
+            await self.when.user_clicks_button(page, "2")
+            await self.then.path_should_be(page, f"/destruction-lists/{str(destruction_list.uuid)}?page=2&is_editing=true")
+            await self.then.zaak_should_be_selected(page, "ZAAK-200")
+            await self.then.zaak_should_be_selected(page, "ZAAK-100")  # First unselected zaak
+
+            await self.when.user_selects_zaak(page, "ZAAK-100")
+            await self.when.user_clicks_button(page, "Vernietigingslijst aanpassen")
+            await self.then.path_should_be(page, f"/destruction-lists/{str(destruction_list.uuid)}")
+
+            # View updated destruction list
+            await self.then.page_should_contain_text(page, "ZAAK-99")
+            await self.when.user_clicks_button(page, "2")
+            await self.then.not_.page_should_contain_text(page, "ZAAK-100")

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_finalize.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_finalize.py
@@ -11,7 +11,7 @@ from openarchiefbeheer.utils.tests.gherkin import GherkinLikeTestCase
 
 
 @tag("e2e")
-class FeatureListCreateTests(GherkinLikeTestCase):
+class FeatureListFinalizeTests(GherkinLikeTestCase):
     async def test_scenario_record_manager_finalizes_list(self):
         async with browser_page() as page:
             record_manager = await self.given.record_manager_exists()

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_mark_ready_to_review.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/features/test_feature_list_mark_ready_to_review.py
@@ -7,7 +7,7 @@ from openarchiefbeheer.utils.tests.gherkin import GherkinLikeTestCase
 
 
 @tag("e2e")
-class FeatureListCreateTests(GherkinLikeTestCase):
+class FeatureListMarkReadyForReviewTests(GherkinLikeTestCase):
     async def test_scenario_record_manager_marks_list_as_ready_to_review(self):
         async with browser_page() as page:
             await self.given.zaken_are_indexed(amount=100)

--- a/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
@@ -79,7 +79,7 @@ class DestructionListViewSetTest(APITestCase):
                 "name": "A test list",
                 "contains_sensitive_info": True,
                 "reviewer": {"user": reviewer.pk},
-                "items": [
+                "add": [
                     {
                         "zaak": "http://localhost:8003/zaken/api/v1/zaken/111-111-111",
                         "extra_zaak_data": {},
@@ -161,7 +161,7 @@ class DestructionListViewSetTest(APITestCase):
                 "assignees": [
                     {"user": reviewer.pk},
                 ],
-                "items": [
+                "add": [
                     {
                         "zaak": "http://localhost:8003/zaken/api/v1/zaken/111-111-111",
                         "extra_zaak_data": {},
@@ -182,7 +182,7 @@ class DestructionListViewSetTest(APITestCase):
         self.assertEqual(
             data,
             {
-                "items": [
+                "add": [
                     {
                         "zaak": [
                             _(
@@ -228,7 +228,7 @@ class DestructionListViewSetTest(APITestCase):
         data = {
             "name": "An updated test list",
             "contains_sensitive_info": False,
-            "items": [
+            "add": [
                 {
                     "zaak": "http://localhost:8003/zaken/api/v1/zaken/111-111-111",
                     "extra_zaak_data": {"key": "value"},
@@ -251,7 +251,7 @@ class DestructionListViewSetTest(APITestCase):
         destruction_list.refresh_from_db()
 
         self.assertEqual(destruction_list.name, "An updated test list")
-        self.assertEqual(destruction_list.items.all().count(), 1)
+        self.assertEqual(destruction_list.items.all().count(), 3)
 
     def test_cannot_update_destruction_list_if_not_new(self):
         record_manager = UserFactory.create(post__can_start_destruction=True)

--- a/backend/src/openarchiefbeheer/destruction/tests/test_serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_serializers.py
@@ -362,7 +362,7 @@ class DestructionListSerializerTests(TestCase):
             with_zaak=True,
         )
 
-        zaak = ZaakFactory.create()
+        ZaakFactory.create()
 
         # We are removing 2 zaken from the destruction list
         data = {

--- a/backend/src/openarchiefbeheer/utils/tests/gherkin.py
+++ b/backend/src/openarchiefbeheer/utils/tests/gherkin.py
@@ -476,7 +476,7 @@ class GherkinLikeTestCase(PlaywrightTestCase):
 
         async def page_should_contain_text(self, page, text):
             locator = page.get_by_text(text).nth(0)
-            await expect(locator).to_be_attached()
+            await expect(locator).to_be_visible()
 
         async def path_should_be(self, page, path):
             await self.url_should_be(page, self.testcase.live_server_url + path)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@maykin-ui/admin-ui": "^0.0.36",
+        "@maykin-ui/admin-ui": "^0.0.37",
         "@storybook/test-runner": "^0.18.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3635,9 +3635,9 @@
       "license": "MIT"
     },
     "node_modules/@maykin-ui/admin-ui": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@maykin-ui/admin-ui/-/admin-ui-0.0.36.tgz",
-      "integrity": "sha512-mHnvLVZKnlBFeSBdknIWSdiVvkRLjNzI9WE6AT0EbLPDRN7zxiAu2vTXHRItDx5kPKULIndZr0EwZBOGFXpI9Q==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@maykin-ui/admin-ui/-/admin-ui-0.0.37.tgz",
+      "integrity": "sha512-KhTrN1Yelbcz0OHSnpxD/s3KzrXu7Z+/Z6Is0RJXCLSjZ05KDfpjJLAPCQlpAJb2oyYwY5x8IiDSPLXW7tVGfA==",
       "dependencies": {
         "@floating-ui/react": "^0.26.6",
         "@heroicons/react": "^2.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@maykin-ui/admin-ui": "^0.0.36",
+    "@maykin-ui/admin-ui": "^0.0.37",
     "@storybook/test-runner": "^0.18.2",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,7 +91,7 @@ function App() {
             },
             "spacer",
             <>
-              {state === "loading" ? (
+              {state !== "idle" ? (
                 <P title="Bezig met laden...">
                   <Solid.ArrowPathIcon
                     spin

--- a/frontend/src/lib/api/destructionLists.ts
+++ b/frontend/src/lib/api/destructionLists.ts
@@ -50,6 +50,8 @@ export type DestructionListStatus = (typeof DESTRUCTION_LIST_STATUSES)[number];
 
 export type DestructionListUpdateData = {
   assignees?: DestructionListAssigneeUpdate[];
+  add?: DestructionListItemUpdate[];
+  remove?: DestructionListItemUpdate[];
   items?: DestructionListItemUpdate[];
   comment?: string;
 };

--- a/frontend/src/lib/api/destructionLists.ts
+++ b/frontend/src/lib/api/destructionLists.ts
@@ -52,7 +52,6 @@ export type DestructionListUpdateData = {
   assignees?: DestructionListAssigneeUpdate[];
   add?: DestructionListItemUpdate[];
   remove?: DestructionListItemUpdate[];
-  items?: DestructionListItemUpdate[];
   comment?: string;
 };
 
@@ -74,7 +73,7 @@ export type DestructionListMarkAsFinalData = {
  * Create a new destruction list.
  * @param name
  * @param zaken
- * @param assignees
+ * @param assigneeId
  * @param zaakFilters
  * @param allZakenSelected
  */
@@ -90,7 +89,7 @@ export async function createDestructionList(
   const destructionList = {
     name,
     reviewer: { user: JSON.parse(assigneeId) },
-    items: urls.map((url) => ({ zaak: url })),
+    add: urls.map((url) => ({ zaak: url })),
     selectAll: allZakenSelected,
     zaakFilters: JSON.parse(zaakFilters),
   };

--- a/frontend/src/pages/destructionlist/abstract/BaseListView.tsx
+++ b/frontend/src/pages/destructionlist/abstract/BaseListView.tsx
@@ -119,7 +119,6 @@ export function BaseListView({
     getSelectionDetail,
   );
 
-  // Merge `selectedZakenOnPage`.
   const selectedZakenOnPage = useMemo(() => {
     const deselectedZaakUrls = deSelectedZakenOnPage.map(
       (z) => z.url as string,
@@ -200,7 +199,11 @@ export function BaseListView({
         page,
         sort: sortable && sort,
         selected: selectable
-          ? (selectedZakenOnPage as unknown as AttributeData[])
+          ? ([
+              ...new Map(
+                selectedZakenOnPage.map((zaak) => [zaak["uuid"], zaak]),
+              ).values(),
+            ] as unknown as AttributeData[])
           : [],
         selectionActions: getSelectionActions(),
 

--- a/frontend/src/pages/destructionlist/abstract/BaseListView.tsx
+++ b/frontend/src/pages/destructionlist/abstract/BaseListView.tsx
@@ -194,7 +194,7 @@ export function BaseListView({
           a && b && (a.uuid === b.uuid || a.url === b.url),
         fields,
         filterTransform,
-        loading: state === "loading",
+        loading: state !== "idle",
         objectList: objectList,
         page,
         sort: sortable && sort,

--- a/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
+++ b/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
@@ -167,6 +167,7 @@ export async function destructionListUpdateReviewerAction({
 }
 
 export type DestructionListUpdateZakenActionPayload = {
+  storageKey: string;
   add: string[];
   remove: string[];
 };
@@ -180,7 +181,7 @@ export async function destructionListUpdateZakenAction({
 }: ActionFunctionArgs) {
   const data: UpdateDestructionListAction<DestructionListUpdateZakenActionPayload> =
     await request.json();
-  const { add: _add, remove: _remove } = data.payload;
+  const { storageKey, add: _add, remove: _remove } = data.payload;
   const add = _add.map((url) => ({ zaak: url }));
   const remove = _remove.map((url) => ({ zaak: url }));
 
@@ -191,7 +192,7 @@ export async function destructionListUpdateZakenAction({
 
     throw e;
   }
-
+  await clearZaakSelection(storageKey);
   return redirect(`/destruction-lists/${params.uuid}`);
 }
 

--- a/frontend/src/pages/destructionlist/detail/components/DestructionListEdit/DestructionListEdit.tsx
+++ b/frontend/src/pages/destructionlist/detail/components/DestructionListEdit/DestructionListEdit.tsx
@@ -11,10 +11,7 @@ import { useSubmitAction } from "../../../../../hooks";
 import { PaginatedDestructionListItems } from "../../../../../lib/api/destructionListsItem";
 import { ProcessingStatus } from "../../../../../lib/api/processingStatus";
 import { PaginatedZaken } from "../../../../../lib/api/zaken";
-import {
-  getFilteredZaakSelection,
-  getZaakSelection,
-} from "../../../../../lib/zaakSelection/zaakSelection";
+import { getFilteredZaakSelection } from "../../../../../lib/zaakSelection/zaakSelection";
 import { Zaak } from "../../../../../types";
 import { BaseListView } from "../../../abstract";
 import {

--- a/frontend/src/pages/destructionlist/detail/components/DestructionListEdit/DestructionListEdit.tsx
+++ b/frontend/src/pages/destructionlist/detail/components/DestructionListEdit/DestructionListEdit.tsx
@@ -11,10 +11,16 @@ import { useSubmitAction } from "../../../../../hooks";
 import { PaginatedDestructionListItems } from "../../../../../lib/api/destructionListsItem";
 import { ProcessingStatus } from "../../../../../lib/api/processingStatus";
 import { PaginatedZaken } from "../../../../../lib/api/zaken";
-import { getZaakSelection } from "../../../../../lib/zaakSelection/zaakSelection";
+import {
+  getFilteredZaakSelection,
+  getZaakSelection,
+} from "../../../../../lib/zaakSelection/zaakSelection";
 import { Zaak } from "../../../../../types";
 import { BaseListView } from "../../../abstract";
-import { UpdateDestructionListAction } from "../../DestructionListDetail.action";
+import {
+  DestructionListUpdateZakenActionPayload,
+  UpdateDestructionListAction,
+} from "../../DestructionListDetail.action";
 import { DestructionListDetailContext } from "../../DestructionListDetail.loader";
 import { useSecondaryNavigation } from "../../hooks/useSecondaryNavigation";
 
@@ -157,17 +163,26 @@ export function DestructionListEdit() {
    * Gets called when the user updates the zaak selection (adds/remove zaken to/from the destruction list).
    */
   const handleUpdate = async () => {
-    const zaakSelection = await getZaakSelection(storageKey);
-    const zaakUrls = Object.entries(zaakSelection)
-      .filter(([, selection]) => selection.selected)
+    const zaakSelection = await getFilteredZaakSelection(
+      storageKey,
+      false,
+      false,
+    );
+    const add = Object.entries(zaakSelection)
+      .filter(([, { selected }]) => selected)
+      .map(([url]) => url);
+    const remove = Object.entries(zaakSelection)
+      .filter(([, { selected }]) => !selected)
       .map(([url]) => url);
 
-    const action: UpdateDestructionListAction<Record<string, string[]>> = {
-      type: "UPDATE_ZAKEN",
-      payload: {
-        zaakUrls,
-      },
-    };
+    const action: UpdateDestructionListAction<DestructionListUpdateZakenActionPayload> =
+      {
+        type: "UPDATE_ZAKEN",
+        payload: {
+          add,
+          remove,
+        },
+      };
     submitAction(action);
   };
 

--- a/frontend/src/pages/destructionlist/detail/components/DestructionListEdit/DestructionListEdit.tsx
+++ b/frontend/src/pages/destructionlist/detail/components/DestructionListEdit/DestructionListEdit.tsx
@@ -29,7 +29,6 @@ export function DestructionListEdit() {
   const { destructionList, destructionListItems, selectableZaken, storageKey } =
     useLoaderData() as DestructionListDetailContext;
 
-  const [selectionClearedState, setSelectionClearedState] = useState(false);
   const { state } = useNavigation();
   const [urlSearchParams, setUrlSearchParams] = useSearchParams();
   const submitAction = useSubmitAction();
@@ -46,11 +45,9 @@ export function DestructionListEdit() {
   // The initially select items.
   const initiallySelectedZakenOnPage = useMemo(
     () =>
-      selectionClearedState
-        ? []
-        : paginatedDestructionListItems2paginatedZaken(destructionListItems)
-            .results,
-    [selectionClearedState, destructionListItems],
+      paginatedDestructionListItems2paginatedZaken(destructionListItems)
+        .results,
+    [destructionListItems],
   );
 
   // Whether extra fields should be rendered.
@@ -143,17 +140,6 @@ export function DestructionListEdit() {
     urlSearchParams.set("page", "1");
     urlSearchParams.set("is_editing", "true");
     setUrlSearchParams(value ? urlSearchParams : {});
-
-    if (!value) {
-      setSelectionClearedState(false);
-    }
-  };
-
-  /**
-   * Gets called when te selection is cleared.
-   */
-  const handleClearSelection = async () => {
-    setSelectionClearedState(true);
   };
 
   /**
@@ -176,6 +162,7 @@ export function DestructionListEdit() {
       {
         type: "UPDATE_ZAKEN",
         payload: {
+          storageKey,
           add,
           remove,
         },
@@ -194,7 +181,6 @@ export function DestructionListEdit() {
       selectionActions={selectionActions}
       sortable={false}
       storageKey={storageKey}
-      onClearZaakSelection={handleClearSelection}
     ></BaseListView>
   );
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Refactors the implementation of the edit page, removing "items" for updating and replacing it with "add" and/or "remove" records containing the zaak url's to be added or removed from a destruction list.

By explicitly tracking changes to the list instead of overwriting all the selected items we no longer need to store the entire (initial) selection for a destruction list (which may be very large) and send it to to the backend for every change, instead: only mutations (add/remove) are sent.