### PR TITLE
[#498] Add field to Destruction list item serialiser

### DIFF
--- a/backend/src/openarchiefbeheer/destruction/api/filtersets.py
+++ b/backend/src/openarchiefbeheer/destruction/api/filtersets.py
@@ -1,4 +1,4 @@
-from django.db.models import Case, QuerySet, Value, When
+from django.db.models import Case, F, QuerySet, Value, When
 from django.utils.translation import gettext_lazy as _
 
 from django_filters import (
@@ -41,6 +41,13 @@ class DestructionListItemFilterset(FilterSet):
             "to define the exact same ordering as the zaak endpoint"
         ),
     )
+    order_review_ignored = BooleanFilter(
+        field_name="ordering",
+        method="filter_order_review_ignored",
+        help_text=_(
+            "Return the items where a record manager went against the advice of a reviewer first."
+        ),
+    )
 
     class Meta:
         model = DestructionListItem
@@ -49,6 +56,7 @@ class DestructionListItemFilterset(FilterSet):
             "status",
             "processing_status",
             "order_match_zaken",
+            "order_review_ignored",
         )
 
     def filter_in_destruction_list(
@@ -76,6 +84,11 @@ class DestructionListItemFilterset(FilterSet):
         self, queryset: QuerySet[DestructionListItem], name: str, value: str
     ) -> QuerySet[DestructionListItem]:
         return queryset.order_by("zaak__pk")
+
+    def filter_order_review_ignored(
+        self, queryset: QuerySet[DestructionListItem], name: str, value: bool
+    ) -> QuerySet[DestructionListItem]:
+        return queryset.order_by(F("review_advice_ignored").desc(nulls_last=True))
 
 
 class DestructionListFilterset(FilterSet):

--- a/backend/src/openarchiefbeheer/destruction/api/serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/api/serializers.py
@@ -242,7 +242,7 @@ class DestructionListItemReadSerializer(serializers.ModelSerializer):
     review_advice_ignored = serializers.SerializerMethodField(
         help_text=_(
             "Specifies whether the record manager went against"
-            " the advice of a reviewer when processing a review."
+            " the advice of a reviewer when processing the last review."
         ),
         allow_null=True,
     )
@@ -258,7 +258,7 @@ class DestructionListItemReadSerializer(serializers.ModelSerializer):
             "review_advice_ignored",
         )
 
-    @extend_schema_field(build_basic_type((OpenApiTypes.BOOL, OpenApiTypes.NONE)))
+    @extend_schema_field(build_basic_type(OpenApiTypes.BOOL))
     def get_review_advice_ignored(self, item: DestructionListItem) -> bool | None:
         if hasattr(item, "review_advice_ignored"):
             return item.review_advice_ignored

--- a/backend/src/openarchiefbeheer/destruction/api/serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/api/serializers.py
@@ -4,7 +4,8 @@ from django.db import transaction
 from django.db.models import F, Q, QuerySet
 from django.utils.translation import gettext_lazy as _
 
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.plumbing import build_basic_type
+from drf_spectacular.utils import OpenApiTypes, extend_schema_field
 from requests.exceptions import HTTPError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -238,6 +239,13 @@ class DestructionListItemWriteSerializer(serializers.ModelSerializer):
 
 class DestructionListItemReadSerializer(serializers.ModelSerializer):
     zaak = ZaakSerializer(allow_null=True, read_only=True)
+    review_advice_ignored = serializers.SerializerMethodField(
+        help_text=_(
+            "Specifies whether the record manager went against"
+            " the advice of a reviewer when processing a review."
+        ),
+        allow_null=True,
+    )
 
     class Meta:
         model = DestructionListItem
@@ -247,7 +255,23 @@ class DestructionListItemReadSerializer(serializers.ModelSerializer):
             "extra_zaak_data",
             "zaak",
             "processing_status",
+            "review_advice_ignored",
         )
+
+    @extend_schema_field(build_basic_type((OpenApiTypes.BOOL, OpenApiTypes.NONE)))
+    def get_review_advice_ignored(self, item: DestructionListItem) -> bool | None:
+        if hasattr(item, "review_advice_ignored"):
+            return item.review_advice_ignored
+
+        last_review_response = (
+            ReviewItemResponse.objects.filter(review_item__destruction_list_item=item)
+            .order_by("-created")
+            .last()
+        )
+        if last_review_response is None:
+            return
+
+        return last_review_response.action_item == DestructionListItemAction.keep
 
 
 class DestructionListWriteSerializer(serializers.ModelSerializer):

--- a/backend/src/openarchiefbeheer/destruction/api/viewsets.py
+++ b/backend/src/openarchiefbeheer/destruction/api/viewsets.py
@@ -2,16 +2,7 @@ from datetime import date, timedelta
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
-from django.db.models import (
-    Case,
-    F,
-    OuterRef,
-    Prefetch,
-    QuerySet,
-    Subquery,
-    Value,
-    When,
-)
+from django.db.models import Case, OuterRef, Prefetch, QuerySet, Subquery, Value, When
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 
@@ -445,7 +436,7 @@ class DestructionListItemsViewSet(
                 )
             )
         )
-        return qs.order_by(F("review_advice_ignored").desc(nulls_last=True))
+        return qs
 
 
 @extend_schema_view(

--- a/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_destruction_list_items.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_destruction_list_items.py
@@ -7,8 +7,19 @@ from rest_framework.test import APITestCase
 
 from openarchiefbeheer.accounts.tests.factories import UserFactory
 
-from ...constants import InternalStatus, ListItemStatus
-from ..factories import DestructionListFactory, DestructionListItemFactory
+from ...constants import (
+    DestructionListItemAction,
+    InternalStatus,
+    ListItemStatus,
+    ListStatus,
+)
+from ..factories import (
+    DestructionListFactory,
+    DestructionListItemFactory,
+    DestructionListItemReviewFactory,
+    DestructionListReviewFactory,
+    ReviewItemResponseFactory,
+)
 
 
 class DestructionListItemsViewSetTest(APITestCase):
@@ -221,3 +232,49 @@ class DestructionListItemsViewSetTest(APITestCase):
             data["results"][0]["extraZaakData"]["url"],
             "http://localhost:8003/zaken/api/v1/zaken/eafc5f37-4524-43ce-872f-39ff3df11e1e",
         )
+
+    def test_retrieve_items_with_review_responses(self):
+        record_manager = UserFactory.create(post__can_start_destruction=True)
+        review = DestructionListReviewFactory.create(
+            destruction_list__author=record_manager,
+            destruction_list__status=ListStatus.changes_requested,
+        )
+        item_reviews = DestructionListItemReviewFactory.create_batch(
+            3,
+            destruction_list_item__destruction_list=review.destruction_list,
+            review=review,
+        )
+        ReviewItemResponseFactory.create(
+            review_item=item_reviews[1],
+            review_item__review=review,
+            action_item=DestructionListItemAction.keep,
+        )
+        ReviewItemResponseFactory.create(
+            review_item=item_reviews[2],
+            review_item__review=review,
+            action_item=DestructionListItemAction.remove,
+        )
+
+        self.client.force_authenticate(user=record_manager)
+        endpoint = reverse("api:destruction-list-items-list")
+
+        response = self.client.get(
+            endpoint,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+
+        self.assertEqual(
+            data["results"][0]["pk"], item_reviews[1].destruction_list_item.pk
+        )
+        self.assertTrue(data["results"][0]["reviewAdviceIgnored"])
+        self.assertEqual(
+            data["results"][1]["pk"], item_reviews[2].destruction_list_item.pk
+        )
+        self.assertFalse(data["results"][1]["reviewAdviceIgnored"])
+        self.assertEqual(
+            data["results"][2]["pk"], item_reviews[0].destruction_list_item.pk
+        )
+        self.assertIsNone(data["results"][2]["reviewAdviceIgnored"])

--- a/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_destruction_list_items.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_destruction_list_items.py
@@ -256,10 +256,11 @@ class DestructionListItemsViewSetTest(APITestCase):
         )
 
         self.client.force_authenticate(user=record_manager)
-        endpoint = reverse("api:destruction-list-items-list")
+        endpoint = furl(reverse("api:destruction-list-items-list"))
+        endpoint.args["item-order_review_ignored"] = True
 
         response = self.client.get(
-            endpoint,
+            endpoint.url,
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/src/openarchiefbeheer/destruction/tests/serializers/test_destruction_list_item.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/serializers/test_destruction_list_item.py
@@ -1,0 +1,56 @@
+from django.test import TestCase
+
+from openarchiefbeheer.accounts.tests.factories import UserFactory
+
+from ...api.serializers import DestructionListItemReadSerializer
+from ...constants import DestructionListItemAction, ListStatus
+from ..factories import (
+    DestructionListItemReviewFactory,
+    DestructionListReviewFactory,
+    ReviewItemResponseFactory,
+)
+
+
+class TestDestructionListItemSerializer(TestCase):
+    def test_ignored_review_advice(self):
+        record_manager = UserFactory.create(post__can_start_destruction=True)
+        review = DestructionListReviewFactory.create(
+            destruction_list__author=record_manager,
+            destruction_list__status=ListStatus.changes_requested,
+        )
+        item_reviews = DestructionListItemReviewFactory.create_batch(
+            3,
+            destruction_list_item__destruction_list=review.destruction_list,
+            review=review,
+        )
+        ReviewItemResponseFactory.create(
+            review_item=item_reviews[1],
+            review_item__review=review,
+            action_item=DestructionListItemAction.keep,
+        )
+        ReviewItemResponseFactory.create(
+            review_item=item_reviews[2],
+            review_item__review=review,
+            action_item=DestructionListItemAction.remove,
+        )
+
+        with self.subTest("Accepted item"):
+            serialiser = DestructionListItemReadSerializer(
+                instance=item_reviews[0].destruction_list_item
+            )
+
+            self.assertIsNone(serialiser.data["review_advice_ignored"])
+
+        with self.subTest("Item with ignored feedback"):
+            serialiser = DestructionListItemReadSerializer(
+                instance=item_reviews[1].destruction_list_item
+            )
+
+            self.assertTrue(serialiser.data["review_advice_ignored"])
+
+        with self.subTest("Item with accepted feedback"):
+            serialiser = DestructionListItemReadSerializer(
+                instance=item_reviews[2].destruction_list_item
+            )
+
+            self.assertFalse(serialiser.data["review_advice_ignored"])


### PR DESCRIPTION
Partially fixes #498 

This adds the `review_advice_ignored` field to the destruction list item serialiser and added a `item-order_review_ignored` filter to get the destruction list items that need attention first.