### PR TITLE
[#558] Refactor queue destruction endpoint

### DIFF
--- a/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_list_destruction.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_list_destruction.py
@@ -30,13 +30,14 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
 
         self.client.force_authenticate(user=record_manager)
         with freezegun.freeze_time("2024-01-01T21:36:00+02:00"):
-            response = self.client.delete(
+            response = self.client.post(
                 reverse(
-                    "api:destructionlist-detail", kwargs={"uuid": destruction_list.uuid}
+                    "api:destructionlist-queue-destruction",
+                    kwargs={"uuid": destruction_list.uuid},
                 ),
             )
 
-        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
 
         destruction_list.refresh_from_db()
 
@@ -69,13 +70,14 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
                 "openarchiefbeheer.destruction.api.viewsets.delete_destruction_list"
             ) as m_delete,
         ):
-            response = self.client.delete(
+            response = self.client.post(
                 reverse(
-                    "api:destructionlist-detail", kwargs={"uuid": destruction_list.uuid}
+                    "api:destructionlist-queue-destruction",
+                    kwargs={"uuid": destruction_list.uuid},
                 ),
             )
 
-        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         m_delete.assert_called_once()
         self.assertEqual(m_delete.call_args_list[0].args[0].pk, destruction_list.pk)
 
@@ -98,9 +100,10 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
         )
         self.client.force_authenticate(user=record_manager)
         with (freezegun.freeze_time("2024-01-01T21:36:00+02:00"),):
-            response = self.client.delete(
+            response = self.client.post(
                 reverse(
-                    "api:destructionlist-detail", kwargs={"uuid": destruction_list.uuid}
+                    "api:destructionlist-queue-destruction",
+                    kwargs={"uuid": destruction_list.uuid},
                 ),
             )
 
@@ -122,13 +125,14 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
         with patch(
             "openarchiefbeheer.destruction.api.viewsets.delete_destruction_list"
         ):
-            response = self.client.delete(
+            response = self.client.post(
                 reverse(
-                    "api:destructionlist-detail", kwargs={"uuid": destruction_list.uuid}
+                    "api:destructionlist-queue-destruction",
+                    kwargs={"uuid": destruction_list.uuid},
                 ),
             )
 
-        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
 
     def test_cannot_start_destruction_if_not_ready_to_delete(self):
         record_manager = UserFactory.create(post__can_start_destruction=True)
@@ -143,9 +147,10 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
         with patch(
             "openarchiefbeheer.destruction.api.viewsets.delete_destruction_list"
         ) as m_task:
-            response = self.client.delete(
+            response = self.client.post(
                 reverse(
-                    "api:destructionlist-detail", kwargs={"uuid": destruction_list.uuid}
+                    "api:destructionlist-queue-destruction",
+                    kwargs={"uuid": destruction_list.uuid},
                 ),
             )
 
@@ -176,9 +181,10 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
 
         self.client.force_authenticate(user=record_manager)
         with freezegun.freeze_time("2024-01-01T21:36:00+02:00"):
-            response = self.client.delete(
+            response = self.client.post(
                 reverse(
-                    "api:destructionlist-detail", kwargs={"uuid": destruction_list.uuid}
+                    "api:destructionlist-queue-destruction",
+                    kwargs={"uuid": destruction_list.uuid},
                 ),
             )
 
@@ -216,13 +222,14 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
 
         self.client.force_authenticate(user=record_manager)
         with freezegun.freeze_time("2024-01-01T21:36:00+02:00"):
-            response = self.client.delete(
+            response = self.client.post(
                 reverse(
-                    "api:destructionlist-detail", kwargs={"uuid": destruction_list.uuid}
+                    "api:destructionlist-queue-destruction",
+                    kwargs={"uuid": destruction_list.uuid},
                 ),
             )
 
-        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
 
         logs = TimelineLog.objects.for_object(destruction_list).filter(
             template="logging/destruction_list_deletion_triggered.txt"

--- a/frontend/.storybook/mockData.ts
+++ b/frontend/.storybook/mockData.ts
@@ -162,9 +162,9 @@ export const MOCKS = {
     status: "200",
     response: FIXTURE_DESTRUCTION_LIST,
   },
-  DESTRUCTION_LIST_DELETE: {
-    url: "http://localhost:8000/api/v1/destruction-lists/00000000-0000-0000-0000-000000000000", // FIXME
-    method: "DELETE",
+  DESTRUCTION_LIST_QUEUE_DESTRUCTION: {
+    url: "http://localhost:8000/api/v1/destruction-lists/00000000-0000-0000-0000-000000000000/queue_destruction/",
+    method: "POST",
     status: "200",
     response: {},
   },

--- a/frontend/src/lib/api/destructionLists.ts
+++ b/frontend/src/lib/api/destructionLists.ts
@@ -186,7 +186,7 @@ export async function markDestructionListAsFinal(
  * @param uuid
  * @returns
  */
-export async function destroyDestructionList(uuid: string) {
+export async function destructionListQueueDestruction(uuid: string) {
   const response = await request(
     "POST",
     `/destruction-lists/${uuid}/queue_destruction/`,

--- a/frontend/src/lib/api/destructionLists.ts
+++ b/frontend/src/lib/api/destructionLists.ts
@@ -188,13 +188,12 @@ export async function markDestructionListAsFinal(
  */
 export async function destroyDestructionList(uuid: string) {
   const response = await request(
-    "DELETE",
-    `/destruction-lists/${uuid}/`,
+    "POST",
+    `/destruction-lists/${uuid}/queue_destruction/`,
     {},
     { uuid },
   );
-  // Check if the response is a 201 Created status code.
-  if (response.status === 204) {
+  if (response.status === 200) {
     return null;
   }
 

--- a/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
+++ b/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
@@ -16,7 +16,7 @@ import {
 import { clearZaakSelection } from "../../../lib/zaakSelection/zaakSelection";
 
 export type UpdateDestructionListAction<P = JsonValue> = TypedAction<
-  | "DESTROY"
+  | "QUEUE_DESTRUCTION"
   | "CANCEL_DESTROY"
   | "MAKE_FINAL"
   | "PROCESS_REVIEW"
@@ -36,7 +36,7 @@ export async function destructionListUpdateAction({
   const action = data as UpdateDestructionListAction<unknown>;
 
   switch (action.type) {
-    case "DESTROY":
+    case "QUEUE_DESTRUCTION":
       return await destructionListDestroyAction({ request, params });
     case "MAKE_FINAL":
       return await destructionListMakeFinalAction({ request, params });

--- a/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
+++ b/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
@@ -4,7 +4,7 @@ import { redirect } from "react-router-dom";
 import { JsonValue, TypedAction } from "../../../hooks";
 import {
   abort,
-  destroyDestructionList,
+  destructionListQueueDestruction,
   markDestructionListAsFinal,
   markDestructionListAsReadyToReview,
   updateDestructionList,
@@ -37,7 +37,7 @@ export async function destructionListUpdateAction({
 
   switch (action.type) {
     case "QUEUE_DESTRUCTION":
-      return await destructionListDestroyAction({ request, params });
+      return await destructionListQueueDestructionAction({ request, params });
     case "MAKE_FINAL":
       return await destructionListMakeFinalAction({ request, params });
     case "PROCESS_REVIEW":
@@ -73,12 +73,12 @@ export async function destructionListMakeFinalAction({
 /**
  * React Router action (user intents to DESTROY ALL ZAKEN ON THE DESTRUCTION LIST!).
  */
-export async function destructionListDestroyAction({
+export async function destructionListQueueDestructionAction({
   request,
 }: ActionFunctionArgs) {
   const { payload } = await request.json();
   try {
-    await destroyDestructionList(payload.uuid);
+    await destructionListQueueDestruction(payload.uuid);
   } catch (e: unknown) {
     if (e instanceof Response) {
       return await (e as Response).json();

--- a/frontend/src/pages/destructionlist/detail/hooks/useSecondaryNavigation.tsx
+++ b/frontend/src/pages/destructionlist/detail/hooks/useSecondaryNavigation.tsx
@@ -327,7 +327,7 @@ export function useSecondaryNavigation(): ToolbarItem[] {
    */
   const handleDestroy = async () => {
     submitAction({
-      type: "DESTROY",
+      type: "QUEUE_DESTRUCTION",
       payload: {
         uuid: destructionList.uuid,
       },


### PR DESCRIPTION
Partially fixed #558 

I think that it makes more sense to have this endpoint be a POST, and then the endpoint that actually deletes the destruction list resource be a DELETE