### PR TITLE
[#544] Delete destruction list items no longer related to a zaak

### DIFF
--- a/backend/src/openarchiefbeheer/destruction/tests/test_utils.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_utils.py
@@ -1,9 +1,13 @@
+from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
+
+from timeline_logger.models import TimelineLog
 
 from openarchiefbeheer.accounts.tests.factories import UserFactory
 from openarchiefbeheer.zaken.tests.factories import ZaakFactory
 
 from ..constants import ListRole
+from ..models import DestructionListItem
 from ..utils import process_new_reviewer, resync_items_and_zaken
 from .factories import (
     DestructionListAssigneeFactory,
@@ -48,12 +52,20 @@ class UtilsTest(TestCase):
         ZaakFactory.create(url="http://zaken.nl/2")
         item1 = DestructionListItemFactory.create(_zaak_url="http://zaken.nl/1")
         item2 = DestructionListItemFactory.create(_zaak_url="http://zaken.nl/3")
+        item2_pk = item2.pk
+        destruction_list2 = item2.destruction_list
 
         resync_items_and_zaken()
 
         item1.refresh_from_db()
-        item2.refresh_from_db()
 
         self.assertIsNotNone(item1.zaak)
         self.assertEqual(item1.zaak.url, "http://zaken.nl/1")
-        self.assertIsNone(item2.zaak)
+        with self.assertRaises(ObjectDoesNotExist):
+            DestructionListItem.objects.get(pk=item2_pk)
+
+        logs = TimelineLog.objects.for_object(destruction_list2)
+
+        self.assertEqual(logs.count(), 1)
+        self.assertEqual(logs[0].extra_data["number_deleted_items"], 1)
+        self.assertEqual(logs[0].extra_data["number_of_zaken"], 0)

--- a/backend/src/openarchiefbeheer/logging/logevent.py
+++ b/backend/src/openarchiefbeheer/logging/logevent.py
@@ -252,6 +252,21 @@ def destruction_list_deletion_triggered(
     )
 
 
+def destruction_list_items_deleted(
+    destruction_list: DestructionList, number_deleted_items: int
+) -> None:
+    _create_log(
+        model=destruction_list,
+        event="destruction_list_items_deleted",
+        extra_data={
+            "number_deleted_items": number_deleted_items,
+            "number_of_zaken": destruction_list.items.filter(
+                status=ListItemStatus.suggested
+            ).count(),
+        },
+    )
+
+
 def resync_started() -> None:
     return TimelineLog.objects.create(
         template="logging/resync_started.txt",

--- a/backend/src/openarchiefbeheer/logging/templates/logging/destruction_list_items_deleted.txt
+++ b/backend/src/openarchiefbeheer/logging/templates/logging/destruction_list_items_deleted.txt
@@ -1,0 +1,9 @@
+{% load i18n %}{% blocktranslate trimmed with list_name=log.content_object.name %}
+List "{{ list_name }}" has been updated after resyncing the cases with Open Zaak.
+{% endblocktranslate %}
+{% blocktranslate trimmed with number_deleted_items=log.extra_data.number_deleted_items count counter=log.extra_data.number_deleted_items %}
+One item was deleted.{% plural %}{{ number_deleted_items }} items were deleted.
+{% endblocktranslate %}
+{% blocktranslate trimmed with number_of_zaken=log.extra_data.number_of_zaken count counter=log.extra_data.number_of_zaken %}
+There is now one zaak on the list.{% plural %}There are now {{ number_of_zaken }} zaken on the list.
+{% endblocktranslate %}


### PR DESCRIPTION
Fixes #544 

We will probably at some point start seeing some race conditions if users interact with the app during a resync :thinking: 

Maybe we need to do something about it