### PR TITLE
:art: #600 - changed the error on 403 without session

### DIFF
--- a/backend/src/openarchiefbeheer/conf/base.py
+++ b/backend/src/openarchiefbeheer/conf/base.py
@@ -156,6 +156,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "openarchiefbeheer.middleware.CsrfTokenMiddleware",
+    "openarchiefbeheer.middleware.SessionExpiredMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "maykin_2fa.middleware.OTPMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_600_session_expired.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_600_session_expired.py
@@ -8,7 +8,7 @@ from ....constants import ListStatus
 
 
 @tag("e2e")
-@override_settings(SESSION_COOKIE_AGE=3)
+@override_settings(SESSION_COOKIE_AGE=1)
 class Issue600SessionExpired(GherkinLikeTestCase):
     async def test_session_expired(self):
         async with browser_page() as page:

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_600_session_expired.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_600_session_expired.py
@@ -1,0 +1,24 @@
+# fmt: off
+from django.test import override_settings, tag
+
+from openarchiefbeheer.utils.tests.e2e import browser_page
+from openarchiefbeheer.utils.tests.gherkin import GherkinLikeTestCase
+
+from ....constants import ListStatus
+
+
+@tag("e2e")
+@override_settings(SESSION_COOKIE_AGE=3)
+class Issue600SessionExpired(GherkinLikeTestCase):
+    async def test_session_expired(self):
+        async with browser_page() as page:
+            await self.given.list_exists(
+                name="Destruction list to click",
+                status=ListStatus.new,
+                uuid="00000000-0000-0000-0000-000000000000",
+            )
+            await self.when.record_manager_logs_in(page)
+            await self.then.path_should_be(page, "/destruction-lists")
+            await self.when.user_clicks_button(page, "Destruction list to click")
+            await self.then.page_should_contain_text(page, "Zaak-")
+            await self.then.page_should_contain_text(page, "Your session has expired, please log in again.")

--- a/backend/src/openarchiefbeheer/middleware.py
+++ b/backend/src/openarchiefbeheer/middleware.py
@@ -1,5 +1,7 @@
-from django.http import HttpRequest
+from django.conf import settings
+from django.http import HttpRequest, JsonResponse
 from django.middleware.csrf import get_token
+from django.utils.translation import gettext as _
 
 CSRF_TOKEN_HEADER_NAME = "X-CSRFToken"
 
@@ -21,3 +23,36 @@ class CsrfTokenMiddleware:
 
         response[CSRF_TOKEN_HEADER_NAME] = get_token(request)
         return response
+
+
+class SessionExpiredMiddleware:
+    """
+    Inspect the response and if it's a 403, check if the session has expired and return appropriate message
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest):
+        response = self.get_response(request)
+
+        # Stop if response not 403
+        if not response.status_code == 403:
+            return response
+
+        # Stop if not an API route
+        if not request.path_info.startswith("/api"):
+            return response
+
+        # Stop if session cookie is present (not expired)
+        if request.COOKIES.get(settings.SESSION_COOKIE_NAME):
+            return response
+
+        # Session cookie expired, show appropriate message
+        return JsonResponse(
+            {
+                "detail": _("Your session has expired, please log in again."),
+                "code": "session_expired",
+            },
+            status=403,
+        )

--- a/frontend/src/hooks/useAlertOnError.ts
+++ b/frontend/src/hooks/useAlertOnError.ts
@@ -3,7 +3,7 @@ import { useAlert } from "@maykin-ui/admin-ui";
 import { collectErrors } from "../lib/format/error";
 
 /**
- * Hook providing catch handler for hooks implementing data fetching.
+ * Hook providing a catch handler for hooks implementing data fetching.
  * Catch handler shows errors using `useAlert`.
  * @param defaultMessage A default error message shown if the error message
  *  cannot be determined.
@@ -11,10 +11,37 @@ import { collectErrors } from "../lib/format/error";
 export const useAlertOnError = (defaultMessage: string) => {
   const alert = useAlert();
   return async (e: unknown) => {
-    const errors = e instanceof Response ? collectErrors(await e.json()) : [];
-    const message = errors.length ? errors.join() : defaultMessage;
+    const errorJsonBody = e instanceof Response ? await e.json() : null;
+
+    const { onConfirm, confirmLabel } = getAlertOptions(errorJsonBody);
+    const errors = e instanceof Response ? collectErrors(errorJsonBody) : [];
+    const message = errors.length ? errors.join(", ") : defaultMessage;
 
     console.error(e, errors);
-    alert("Foutmelding", message, "Ok");
+    alert("Foutmelding", message, confirmLabel, onConfirm);
   };
 };
+
+/**
+ * Determines the options for the alert based on the error response.
+ * @param errorJsonBody The parsed JSON body of the error response.
+ * @returns { onConfirm, confirmLabel } Options for the alert.
+ */
+function getAlertOptions(errorJsonBody?: { code: string }): {
+  onConfirm?: () => void;
+  confirmLabel: string;
+} {
+  if (errorJsonBody?.code === "session_expired") {
+    return {
+      onConfirm: () => {
+        window.location.href = "/login";
+      },
+      confirmLabel: "Log in",
+    };
+  }
+
+  return {
+    onConfirm: undefined,
+    confirmLabel: "Ok",
+  };
+}

--- a/frontend/src/hooks/useSelectielijstKlasseChoices.test.ts
+++ b/frontend/src/hooks/useSelectielijstKlasseChoices.test.ts
@@ -32,6 +32,7 @@ describe("useSelectielijstKlasseChoices Hook", () => {
         "Foutmelding",
         "Er is een fout opgetreden bij het ophalen van selectielijst klassen!",
         "Ok",
+        undefined,
       );
     });
   });

--- a/frontend/src/lib/format/error.ts
+++ b/frontend/src/lib/format/error.ts
@@ -1,11 +1,16 @@
 /**
  * Takes an errors object and returns a `string[]` with correct messages.
- * @param errors
+ * Filters out irrelevant error codes like "session_expired".
+ * @param errors The error response body.
+ * @returns A list of error messages.
  */
 export function collectErrors(errors: string | object): string[] {
   if (typeof errors === "string") {
     return [errors];
   }
-  const flatten = Object.values(errors || {}).flat();
+
+  const flatten = Object.values(errors || {})
+    .flat()
+    .filter((error) => error !== "session_expired");
   return flatten.reduce((acc, val) => [...acc, ...collectErrors(val)], []);
 }

--- a/frontend/src/lib/format/error.ts
+++ b/frontend/src/lib/format/error.ts
@@ -11,6 +11,6 @@ export function collectErrors(errors: string | object): string[] {
 
   const flatten = Object.values(errors || {})
     .flat()
-    .filter((error) => error !== "session_expired");
+    .filter((error) => !["key", "code"].includes(error));
   return flatten.reduce((acc, val) => [...acc, ...collectErrors(val)], []);
 }


### PR DESCRIPTION
closes #600 

- Added a **backend** middleware to return a `code` on the session expiry edge case
- Added two E2E tests
  - One tests for the issue itself
  - Other one tests our authentication implementation directly (and changed the CSRF test to not hit this edge case anymore)
- Updated **frontend** to add a link to the modal when the `session_expired` code is provided as a response error