### PR TITLE
[#644] Increase SESSION_COOKIE_AGE in e2e test

### DIFF
--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_600_session_expired.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_600_session_expired.py
@@ -8,9 +8,16 @@ from ....constants import ListStatus
 
 
 @tag("e2e")
-@override_settings(SESSION_COOKIE_AGE=1)
+@override_settings(SESSION_COOKIE_AGE=2)
 class Issue600SessionExpired(GherkinLikeTestCase):
     async def test_session_expired(self):
+        """Test error message on page with polling
+
+        If the session has expired, the polling will receive a 403 with
+        a specific error.
+        Note: the SESSION_COOKIE_AGE setting needs to give enough time to the 
+        test to reach the detail page of the destruction list.
+        """
         async with browser_page() as page:
             await self.given.list_exists(
                 name="Destruction list to click",


### PR DESCRIPTION
To give enough time to the test to reach the destruction list detail page before the session is expired.

Fixes #644 