### PR TITLE
[#357] Refactor endpoints with search

### DIFF
--- a/backend/src/openarchiefbeheer/utils/django_filters/backends.py
+++ b/backend/src/openarchiefbeheer/utils/django_filters/backends.py
@@ -1,5 +1,34 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.filters import OrderingFilter
 
 
 class NoModelFilterBackend(DjangoFilterBackend):
     pass
+
+
+class OrderingWithPostFilterBackend(OrderingFilter):
+    """Support ordering params also in the request body."""
+
+    def get_ordering_filters(self, request):
+        return request.query_params or request.data
+
+    def get_ordering(self, request, queryset, view):
+        """
+        Ordering is set by a comma delimited ?ordering=... query parameter.
+
+        The `ordering` query parameter can be overridden by setting
+        the `ordering_param` value on the OrderingFilter or by
+        specifying an `ORDERING_PARAM` value in the API settings.
+        """
+        # Overriding where the filters are coming from (for us from the POST request body).
+        # Normally they are query params.
+        ordering_filters = self.get_ordering_filters(request)
+        params = ordering_filters.get(self.ordering_param)
+        if params:
+            fields = [param.strip() for param in params.split(",")]
+            ordering = self.remove_invalid_fields(queryset, fields, view, request)
+            if ordering:
+                return ordering
+
+        # No ordering was included, or all the ordering fields were invalid
+        return self.get_default_ordering(view)

--- a/backend/src/openarchiefbeheer/utils/paginators.py
+++ b/backend/src/openarchiefbeheer/utils/paginators.py
@@ -4,3 +4,17 @@ from rest_framework.pagination import PageNumberPagination as _PageNumberPaginat
 class PageNumberPagination(_PageNumberPagination):
     page_size_query_param = "page_size"
     page_size = 100
+
+
+class PageNumberPaginationWithPost(_PageNumberPagination):
+    """Support pagination param also in request body"""
+
+    page_size_query_param = "page_size"
+    page_size = 100
+
+    def get_page_number(self, request, paginator):
+        params = request.query_params or request.data
+        page_number = params.get(self.page_query_param) or 1
+        if page_number in self.last_page_strings:
+            page_number = paginator.num_pages
+        return page_number

--- a/backend/src/openarchiefbeheer/zaken/api/filtersets.py
+++ b/backend/src/openarchiefbeheer/zaken/api/filtersets.py
@@ -22,6 +22,7 @@ from django_filters import (
     NumberFilter,
     UUIDFilter,
 )
+from django_filters.rest_framework import DjangoFilterBackend
 
 from openarchiefbeheer.destruction.constants import ListItemStatus
 from openarchiefbeheer.destruction.models import (
@@ -282,3 +283,12 @@ class ZaakFilterSet(FilterSet):
         )
 
         return zaken_with_afdeling.filter(behandelend_afdeling__contains=value)
+
+
+class ZaakFilterBackend(DjangoFilterBackend):
+    def get_filterset_kwargs(self, request, queryset, view):
+        return {
+            "data": request.query_params or request.data,
+            "queryset": queryset,
+            "request": request,
+        }

--- a/backend/src/openarchiefbeheer/zaken/api/viewsets.py
+++ b/backend/src/openarchiefbeheer/zaken/api/viewsets.py
@@ -3,7 +3,6 @@ from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
-from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import IsAuthenticated
 
 from openarchiefbeheer.destruction.api.permissions import (
@@ -11,7 +10,10 @@ from openarchiefbeheer.destruction.api.permissions import (
     CanReviewPermission,
     CanStartDestructionPermission,
 )
-from openarchiefbeheer.utils.paginators import PageNumberPagination
+from openarchiefbeheer.utils.django_filters.backends import (
+    OrderingWithPostFilterBackend,
+)
+from openarchiefbeheer.utils.paginators import PageNumberPaginationWithPost
 
 from ..models import Zaak
 from .filtersets import ZaakFilterBackend, ZaakFilterSet
@@ -40,8 +42,8 @@ class ZakenViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         IsAuthenticated
         & (CanStartDestructionPermission | CanReviewPermission | CanCoReviewPermission)
     ]
-    pagination_class = PageNumberPagination
-    filter_backends = (ZaakFilterBackend, OrderingFilter)
+    pagination_class = PageNumberPaginationWithPost
+    filter_backends = (ZaakFilterBackend, OrderingWithPostFilterBackend)
     filterset_class = ZaakFilterSet
     ordering_fields = "__all__"
 

--- a/backend/src/openarchiefbeheer/zaken/api/viewsets.py
+++ b/backend/src/openarchiefbeheer/zaken/api/viewsets.py
@@ -1,8 +1,8 @@
 from django.utils.translation import gettext_lazy as _
 
-from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, viewsets
+from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import IsAuthenticated
 
@@ -14,14 +14,23 @@ from openarchiefbeheer.destruction.api.permissions import (
 from openarchiefbeheer.utils.paginators import PageNumberPagination
 
 from ..models import Zaak
-from .filtersets import ZaakFilterSet
+from .filtersets import ZaakFilterBackend, ZaakFilterSet
 from .serializers import ZaakSerializer
 
 
 @extend_schema_view(
     list=extend_schema(
         summary=_("List zaken"),
+        tags=["Zaken"],
         description=_("List cases retrieved and cached from Open Zaak."),
+    ),
+    search=extend_schema(
+        tags=["Zaken"],
+        summary=_("Search zaken"),
+        description=_(
+            "Search cases retrieved and cached from Open Zaak. "
+            "You can use the same arguments in the JSON body as the query params of the 'List Zaken' endpoint "
+        ),
     ),
 )
 class ZakenViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -32,6 +41,10 @@ class ZakenViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         & (CanStartDestructionPermission | CanReviewPermission | CanCoReviewPermission)
     ]
     pagination_class = PageNumberPagination
-    filter_backends = (DjangoFilterBackend, OrderingFilter)
+    filter_backends = (ZaakFilterBackend, OrderingFilter)
     filterset_class = ZaakFilterSet
     ordering_fields = "__all__"
+
+    @action(detail=False, methods=["post"], name="search")
+    def search(self, request, *args, **kwargs) -> None:
+        return self.list(request, *args, **kwargs)

--- a/backend/src/openarchiefbeheer/zaken/tests/test_filtersets.py
+++ b/backend/src/openarchiefbeheer/zaken/tests/test_filtersets.py
@@ -410,3 +410,24 @@ class FilterZakenTests(APITestCase):
 
         self.assertIn(zaken_2[0].url, urls_zaken)
         self.assertIn(zaken_2[1].url, urls_zaken)
+
+    def test_filter_on_zaaktype_with_post(self):
+        ZaakFactory.create_batch(3, identificatie="ZAAK-01")
+        zaken_2 = ZaakFactory.create_batch(2, identificatie="ZAAK-02")
+
+        user = UserFactory(username="record_manager", post__can_start_destruction=True)
+
+        self.client.force_authenticate(user)
+        response = self.client.post(
+            reverse("api:zaken-search"),
+            data={"zaaktype__in": ",".join([zaken_2[0].zaaktype, zaken_2[1].zaaktype])},
+        )
+        data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(data["count"], 2)
+
+        urls_zaken = [zaak["url"] for zaak in data["results"]]
+
+        self.assertIn(zaken_2[0].url, urls_zaken)
+        self.assertIn(zaken_2[1].url, urls_zaken)

--- a/backend/src/openarchiefbeheer/zaken/tests/test_views.py
+++ b/backend/src/openarchiefbeheer/zaken/tests/test_views.py
@@ -209,28 +209,54 @@ class ZaaktypenChoicesViewsTestCase(APITestCase):
         DestructionListItemFactory.create_batch(2, with_zaak=True)
 
         self.client.force_authenticate(user=user)
-        endpoint = furl(reverse("api:retrieve-zaaktypen-choices"))
-        endpoint.args["in_destruction_list"] = destruction_list.uuid
+        url = reverse("api:retrieve-zaaktypen-choices")
 
-        response = self.client.get(endpoint.url)
+        with self.subTest("with GET"):
+            endpoint = furl(url)
+            endpoint.args["in_destruction_list"] = destruction_list.uuid
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+            response = self.client.get(endpoint.url)
 
-        choices = sorted(response.json(), key=lambda choice: choice["label"])
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(choices), 2)
-        self.assertEqual(choices[0]["label"], "ZAAKTYPE 1.1 (ZAAKTYPE-1)")
-        self.assertEqual(choices[1]["label"], "ZAAKTYPE 2.0 (ZAAKTYPE-2)")
+            choices = sorted(response.json(), key=lambda choice: choice["label"])
 
-        values = choices[0]["value"].split(",")
+            self.assertEqual(len(choices), 2)
+            self.assertEqual(choices[0]["label"], "ZAAKTYPE 1.1 (ZAAKTYPE-1)")
+            self.assertEqual(choices[1]["label"], "ZAAKTYPE 2.0 (ZAAKTYPE-2)")
 
-        self.assertEqual(len(values), 2)
-        self.assertIn(items_in_list[0].zaak._expand["zaaktype"]["url"], values)
-        self.assertIn(items_in_list[1].zaak._expand["zaaktype"]["url"], values)
+            values = choices[0]["value"].split(",")
 
-        self.assertEqual(
-            choices[1]["value"], items_in_list[2].zaak._expand["zaaktype"]["url"]
-        )
+            self.assertEqual(len(values), 2)
+            self.assertIn(items_in_list[0].zaak._expand["zaaktype"]["url"], values)
+            self.assertIn(items_in_list[1].zaak._expand["zaaktype"]["url"], values)
+
+            self.assertEqual(
+                choices[1]["value"], items_in_list[2].zaak._expand["zaaktype"]["url"]
+            )
+
+        with self.subTest("with POST"):
+            response = self.client.post(
+                url, data={"in_destruction_list": destruction_list.uuid}
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            choices = sorted(response.json(), key=lambda choice: choice["label"])
+
+            self.assertEqual(len(choices), 2)
+            self.assertEqual(choices[0]["label"], "ZAAKTYPE 1.1 (ZAAKTYPE-1)")
+            self.assertEqual(choices[1]["label"], "ZAAKTYPE 2.0 (ZAAKTYPE-2)")
+
+            values = choices[0]["value"].split(",")
+
+            self.assertEqual(len(values), 2)
+            self.assertIn(items_in_list[0].zaak._expand["zaaktype"]["url"], values)
+            self.assertIn(items_in_list[1].zaak._expand["zaaktype"]["url"], values)
+
+            self.assertEqual(
+                choices[1]["value"], items_in_list[2].zaak._expand["zaaktype"]["url"]
+            )
 
     @tag("gh-303")
     def test_retrieve_zaaktypen_choices_for_destruction_list_if_zaaktype_id_empty(self):

--- a/frontend/.storybook/mockData.ts
+++ b/frontend/.storybook/mockData.ts
@@ -5,6 +5,7 @@ import {
   coReviewsFactory,
   destructionListAssigneesFactory,
   destructionListFactory,
+  paginatedZakenFactory,
   recordManagerFactory,
   userFactory,
   usersFactory,
@@ -200,6 +201,13 @@ export const MOCKS = {
     method: "POST",
     status: "201",
     response: {},
+  },
+  // ZAKEN
+  ZAKEN_SEARCH: {
+    url: "http://localhost:8000/api/v1/zaken/search/",
+    method: "POST",
+    status: 200,
+    response: paginatedZakenFactory(),
   },
 };
 

--- a/frontend/.storybook/mockData.ts
+++ b/frontend/.storybook/mockData.ts
@@ -50,6 +50,12 @@ export const MOCKS = {
     status: 200,
     response: zaaktypeChoicesFactory(),
   },
+  DESTRUCTION_SEARCH_ZAAKTYPE_CHOICES: {
+    url: "http://localhost:8000/api/v1/_zaaktypen-choices/",
+    method: "POST",
+    status: 200,
+    response: zaaktypeChoicesFactory(),
+  },
   DESTRUCTION_LISTS: {
     url: "http://localhost:8000/api/v1/destruction-lists/?ordering=-created",
     method: "GET",

--- a/frontend/src/lib/api/private.ts
+++ b/frontend/src/lib/api/private.ts
@@ -124,11 +124,18 @@ export async function listZaaktypeChoices(
         params.set("notInDestructionList", "true");
       }
 
-      const endpoint = external
-        ? "/_external-zaaktypen-choices/"
-        : "/_zaaktypen-choices/";
+      let response;
+      if (external) {
+        response = await request(
+          "GET",
+          "/_external-zaaktypen-choices/",
+          params,
+        );
+      } else {
+        const filters = Object.fromEntries(params.entries());
+        response = await request("POST", "/_zaaktypen-choices/", {}, filters);
+      }
 
-      const response = await request("GET", endpoint, params);
       const promise: Promise<Option[]> = response.json();
 
       return promise;

--- a/frontend/src/lib/api/zaken.test.ts
+++ b/frontend/src/lib/api/zaken.test.ts
@@ -1,9 +1,9 @@
 import fetchMock from "jest-fetch-mock";
 
 import { zakenFactory } from "../../fixtures/zaak";
-import { listZaken } from "./zaken";
+import { searchZaken } from "./zaken";
 
-describe("listZaken", () => {
+describe("searchZaken", () => {
   beforeAll(() => {
     fetchMock.enableMocks();
   });
@@ -15,11 +15,11 @@ describe("listZaken", () => {
   it("should return a list of users on success", async () => {
     const zaken = zakenFactory();
     fetchMock.mockResponseOnce(JSON.stringify(zaken));
-    await expect(listZaken()).resolves.toEqual(zaken);
+    await expect(searchZaken()).resolves.toEqual(zaken);
   });
 
   it("should throw an error on failure", async () => {
     fetchMock.mockRejectOnce(new Error("Internal Server Error"));
-    await expect(listZaken()).rejects.toThrow("Internal Server Error");
+    await expect(searchZaken()).rejects.toThrow("Internal Server Error");
   });
 });

--- a/frontend/src/lib/api/zaken.ts
+++ b/frontend/src/lib/api/zaken.ts
@@ -8,10 +8,13 @@ export type PaginatedZaken = PaginatedResults<Zaak>;
  * Retrieve zaken using the configured ZRC service. For information over the query parameters accepted and the schema of
  * the response, look at the '/zaken/api/v1/zaken' list endpoint of Open Zaak.
  */
-export async function listZaken(
-  params?: URLSearchParams | Record<string, string>,
-) {
-  const response = await request("GET", "/zaken/", params);
+export async function listZaken(params?: Record<string, string>) {
+  const response = await request(
+    "POST",
+    "/zaken/search/",
+    new URLSearchParams(),
+    params,
+  );
   const promise: Promise<PaginatedZaken> = response.json();
   return promise;
 }

--- a/frontend/src/lib/api/zaken.ts
+++ b/frontend/src/lib/api/zaken.ts
@@ -5,10 +5,10 @@ import { request } from "./request";
 export type PaginatedZaken = PaginatedResults<Zaak>;
 
 /**
- * Retrieve zaken using the configured ZRC service. For information over the query parameters accepted and the schema of
- * the response, look at the '/zaken/api/v1/zaken' list endpoint of Open Zaak.
+ * Search zaken using the configured ZRC service. For information over the filters that can be passed in the
+ * request body, look at query params of the '/zaken/api/v1/zaken' list endpoint of Open Zaak.
  */
-export async function listZaken(params?: Record<string, string>) {
+export async function searchZaken(params?: Record<string, string>) {
   const response = await request(
     "POST",
     "/zaken/search/",

--- a/frontend/src/pages/destructionlist/create/DestructionListCreate.loader.ts
+++ b/frontend/src/pages/destructionlist/create/DestructionListCreate.loader.ts
@@ -2,7 +2,7 @@ import { LoaderFunctionArgs } from "@remix-run/router/utils";
 
 import { User } from "../../../lib/api/auth";
 import { listReviewers } from "../../../lib/api/reviewers";
-import { PaginatedZaken, listZaken } from "../../../lib/api/zaken";
+import { PaginatedZaken, searchZaken } from "../../../lib/api/zaken";
 import {
   canStartDestructionListRequired,
   loginRequired,
@@ -35,7 +35,7 @@ export const destructionListCreateLoader = loginRequired(
 
       // Fetch reviewers, zaken, and choices concurrently
       const [zaken, reviewers] = await Promise.all([
-        listZaken(searchParamsZakenEndpoint),
+        searchZaken(searchParamsZakenEndpoint),
         listReviewers(),
       ]);
 

--- a/frontend/src/pages/destructionlist/create/DestructionListCreate.loader.ts
+++ b/frontend/src/pages/destructionlist/create/DestructionListCreate.loader.ts
@@ -22,19 +22,20 @@ export const destructionListCreateLoader = loginRequired(
     async ({
       request,
     }: LoaderFunctionArgs): Promise<DestructionListCreateContext> => {
+      const searchParams = new URL(request.url).searchParams;
+
       const searchParamsZakenEndpoint: Record<string, string> = {
         not_in_destruction_list: "true",
       };
-      const searchParams = new URL(request.url).searchParams;
 
-      // Update search params efficiently
-      Object.entries(searchParamsZakenEndpoint).forEach(([key, value]) =>
-        searchParams.set(key, value),
-      );
+      for (const [key, value] of searchParams) {
+        searchParamsZakenEndpoint[key] = value;
+      }
+      searchParams.set("not_in_destruction_list", "true");
 
       // Fetch reviewers, zaken, and choices concurrently
       const [zaken, reviewers] = await Promise.all([
-        listZaken(searchParams),
+        listZaken(searchParamsZakenEndpoint),
         listReviewers(),
       ]);
 

--- a/frontend/src/pages/destructionlist/create/DestructionListCreate.stories.tsx
+++ b/frontend/src/pages/destructionlist/create/DestructionListCreate.stories.tsx
@@ -33,6 +33,7 @@ const meta: Meta<typeof DestructionListCreatePage> = {
       MOCKS.OIDC_INFO,
       MOCKS.SELECTIE_LIJST_CHOICES,
       MOCKS.ZAAKTYPE_CHOICES,
+      MOCKS.ZAKEN_SEARCH,
       {
         url: "http://localhost:8000/api/v1/whoami/",
         method: "GET",

--- a/frontend/src/pages/destructionlist/create/DestructionListCreate.stories.tsx
+++ b/frontend/src/pages/destructionlist/create/DestructionListCreate.stories.tsx
@@ -33,6 +33,7 @@ const meta: Meta<typeof DestructionListCreatePage> = {
       MOCKS.OIDC_INFO,
       MOCKS.SELECTIE_LIJST_CHOICES,
       MOCKS.ZAAKTYPE_CHOICES,
+      MOCKS.DESTRUCTION_SEARCH_ZAAKTYPE_CHOICES,
       MOCKS.ZAKEN_SEARCH,
       {
         url: "http://localhost:8000/api/v1/whoami/",

--- a/frontend/src/pages/destructionlist/detail/DestructionListDetail.loader.ts
+++ b/frontend/src/pages/destructionlist/detail/DestructionListDetail.loader.ts
@@ -22,7 +22,7 @@ import {
   ReviewResponse,
   getLatestReviewResponse,
 } from "../../../lib/api/reviewResponse";
-import { PaginatedZaken, listZaken } from "../../../lib/api/zaken";
+import { PaginatedZaken, searchZaken } from "../../../lib/api/zaken";
 import {
   canViewDestructionListRequired,
   loginRequired,
@@ -95,7 +95,7 @@ export const destructionListDetailLoader = loginRequired(
         async (): Promise<PaginatedDestructionListItems> => {
           const params = searchParams;
           if (isEditing) {
-            params["item-order_match_zaken"] = "true"; // Must be in sync with `listZaken()` ordering.
+            params["item-order_match_zaken"] = "true"; // Must be in sync with `searchZaken()` ordering.
           }
           return reviewItemsWithZaak
             ? {
@@ -158,7 +158,7 @@ export const destructionListDetailLoader = loginRequired(
               previous: null,
               results: [],
             } as PaginatedZaken)
-          : listZaken({
+          : searchZaken({
               ...searchParams,
               not_in_destruction_list_except: uuid,
             });

--- a/frontend/src/pages/settings/pages/short-procedure/ShortProcedureSettingsPage.stories.tsx
+++ b/frontend/src/pages/settings/pages/short-procedure/ShortProcedureSettingsPage.stories.tsx
@@ -32,6 +32,7 @@ const meta: Meta<typeof ShortProcedureSettingsPage> = {
   parameters: {
     mockData: [
       MOCKS.OIDC_INFO,
+      MOCKS.DESTRUCTION_SEARCH_ZAAKTYPE_CHOICES,
       {
         url: "http://localhost:8000/api/v1/whoami/",
         method: "GET",


### PR DESCRIPTION
Fixes #357

The fix was a bit more invasive than expected.

I created a new search endpoint for the:
- Zaken endpoint
- Local zaaktypen choices endpoint

These endpoints do the same as the GET, but with a POST. The filter params then are passed into the request body instead of query params in the URL.

Since the Zaken list endpoint supports ordering and pagination, I had to support
passing these query params also through the request body.