### PR TITLE
:construction: #733 - frontend work related to showing report errors

### DIFF
--- a/backend/src/openarchiefbeheer/destruction/api/permissions.py
+++ b/backend/src/openarchiefbeheer/destruction/api/permissions.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import permissions
 
-from ..constants import ListStatus
+from ..constants import InternalStatus, ListStatus
 
 
 class CanStartDestructionPermission(permissions.BasePermission):
@@ -99,7 +99,11 @@ class CanQueueDestruction(permissions.BasePermission):
         return request.user.has_perm("accounts.can_start_destruction")
 
     def has_object_permission(self, request, view, destruction_list):
-        return destruction_list.status == ListStatus.ready_to_delete
+        return destruction_list.status == ListStatus.ready_to_delete or (
+            # The destruction list can have status "deleted" if the creation of the destruction report failed
+            destruction_list.status == ListStatus.deleted
+            and destruction_list.processing_status == InternalStatus.failed
+        )
 
 
 class CanDeleteList(permissions.BasePermission):

--- a/backend/src/openarchiefbeheer/destruction/api/permissions.py
+++ b/backend/src/openarchiefbeheer/destruction/api/permissions.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import permissions
 
-from ..constants import InternalStatus, ListStatus
+from ..constants import ListStatus
 
 
 class CanStartDestructionPermission(permissions.BasePermission):
@@ -99,11 +99,7 @@ class CanQueueDestruction(permissions.BasePermission):
         return request.user.has_perm("accounts.can_start_destruction")
 
     def has_object_permission(self, request, view, destruction_list):
-        return destruction_list.status == ListStatus.ready_to_delete or (
-            # The destruction list can have status "deleted" if the creation of the destruction report failed
-            destruction_list.status == ListStatus.deleted
-            and destruction_list.processing_status == InternalStatus.failed
-        )
+        return destruction_list.can_queue_destruction
 
 
 class CanDeleteList(permissions.BasePermission):

--- a/backend/src/openarchiefbeheer/destruction/models.py
+++ b/backend/src/openarchiefbeheer/destruction/models.py
@@ -307,6 +307,14 @@ class DestructionList(models.Model):
             endpoint = furl(zios[0]["informatieobject"]) / "download"
             return endpoint.url
 
+    @property
+    def can_queue_destruction(self) -> bool:
+        return self.status == ListStatus.ready_to_delete or (
+            # The destruction list can have status "deleted" if the creation of the destruction report failed
+            self.status == ListStatus.deleted
+            and self.processing_status == InternalStatus.failed
+        )
+
 
 class DestructionListItem(models.Model):
     destruction_list = models.ForeignKey(

--- a/backend/src/openarchiefbeheer/destruction/tasks.py
+++ b/backend/src/openarchiefbeheer/destruction/tasks.py
@@ -61,7 +61,7 @@ def delete_destruction_list(destruction_list: DestructionList) -> None:
         )
         return
 
-    if destruction_list.status != ListStatus.ready_to_delete:
+    if not destruction_list.can_queue_destruction:
         logger.warning(
             "Cannot proceed with deleting list %s since it has status %s.",
             destruction_list.name,

--- a/backend/src/openarchiefbeheer/destruction/tests/test_tasks.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_tasks.py
@@ -776,6 +776,20 @@ class ProcessDeletingZakenTests(TestCase):
 
         m.assert_called_once_with(destruction_list)
 
+    def test_queue_deletion_after_report_failure(self):
+        destruction_list = DestructionListFactory.create(
+            status=ListStatus.deleted,
+            processing_status=InternalStatus.failed,
+            planned_destruction_date=date(2025, 3, 23),
+        )
+
+        with (freeze_time("2025-03-24"),):
+            delete_destruction_list(destruction_list)
+
+        destruction_list.refresh_from_db()
+
+        self.assertEqual(destruction_list.processing_status, InternalStatus.processing)
+
     @tag("gh-473")
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     def test_traceback_from_failure_is_saved(self):

--- a/frontend/.storybook/mockData.ts
+++ b/frontend/.storybook/mockData.ts
@@ -115,6 +115,7 @@ export const MOCKS = {
       destructionListFactory({
         name: "My ninth destruction list",
         status: "deleted",
+        processingStatus: "succeeded",
       }),
       // No planned destruction date
       destructionListFactory({
@@ -122,6 +123,12 @@ export const MOCKS = {
         status: "ready_to_delete",
         processingStatus: "processing",
         plannedDestructionDate: null,
+      }),
+      // Deleted but report failed
+      destructionListFactory({
+        name: "My eleventh destruction list",
+        status: "deleted",
+        processingStatus: "failed",
       }),
     ],
   },

--- a/frontend/src/lib/auth/permissions.ts
+++ b/frontend/src/lib/auth/permissions.ts
@@ -170,7 +170,10 @@ export const canDownloadReport: DestructionListPermissionCheck = (
   if (!user.role.canStartDestruction) {
     return false;
   }
-  return destructionList.status === "deleted";
+  return (
+    destructionList.status === "deleted" &&
+    destructionList.processingStatus === "succeeded"
+  );
 };
 
 export const canRenameDestructionList: DestructionListPermissionCheck = (

--- a/frontend/src/lib/format/destructionList.ts
+++ b/frontend/src/lib/format/destructionList.ts
@@ -1,0 +1,17 @@
+import { PaginatedDestructionListItems } from "../api/destructionListsItem";
+import { PaginatedZaken } from "../api/zaken";
+
+/**
+ * Converts `PaginatedDestructionListItems` to `PaginatedZaken`.
+ */
+export function paginatedDestructionListItems2paginatedZaken(
+  paginatedDestructionListItems: PaginatedDestructionListItems,
+): PaginatedZaken {
+  return {
+    ...paginatedDestructionListItems,
+    results: paginatedDestructionListItems.results
+      .map((dli) => ({ ...dli.zaak, processingStatus: dli.processingStatus }))
+      // @ts-expect-error - FIXME: Adding "processingStatus" to zaak.
+      .filter((v): v is Zaak => Boolean(v)) as Zaak[],
+  };
+}

--- a/frontend/src/pages/destructionlist/detail/DestructionListDetail.tsx
+++ b/frontend/src/pages/destructionlist/detail/DestructionListDetail.tsx
@@ -22,9 +22,9 @@ export function DestructionListDetailPage() {
       const isInReview = destructionList.status === "changes_requested";
 
       if (isInReview) {
-        navigate("process-review");
+        navigate("process-review", { replace: true });
       } else {
-        navigate("edit");
+        navigate("edit", { replace: true });
       }
     }
   }, [outlet]);

--- a/frontend/src/pages/destructionlist/detail/pages/process-review/DestructionListProcessReviewPage.tsx
+++ b/frontend/src/pages/destructionlist/detail/pages/process-review/DestructionListProcessReviewPage.tsx
@@ -11,8 +11,8 @@ import { useMemo, useState } from "react";
 import { useRevalidator, useRouteLoaderData } from "react-router-dom";
 
 import { useZaakReviewStatuses, useZaakSelection } from "../../../../../hooks";
-import { PaginatedDestructionListItems } from "../../../../../lib/api/destructionListsItem";
 import { PaginatedZaken } from "../../../../../lib/api/zaken";
+import { paginatedDestructionListItems2paginatedZaken } from "../../../../../lib/format/destructionList";
 import { ZaakSelection } from "../../../../../lib/zaakSelection";
 import { Zaak } from "../../../../../types";
 import { BaseListView } from "../../../abstract";
@@ -93,21 +93,6 @@ export function DestructionListProcessReviewPage() {
             .results,
     [selectionClearedState, destructionListItems],
   );
-
-  /**
-   * Converts `PaginatedDestructionListItems` to `PaginatedZaken`.
-   */
-  function paginatedDestructionListItems2paginatedZaken(
-    paginatedDestructionListItems: PaginatedDestructionListItems,
-  ): PaginatedZaken {
-    return {
-      ...paginatedDestructionListItems,
-      results: paginatedDestructionListItems.results
-        .map((dli) => ({ ...dli.zaak, processingStatus: dli.processingStatus }))
-        // @ts-expect-error - FIXME: Adding "processingStatus" to zaak.
-        .filter((v): v is Zaak => Boolean(v)) as Zaak[],
-    };
-  }
 
   // Whether extra fields should be rendered.
   const extraFields: TypedField[] = [

--- a/frontend/src/pages/landing/Landing.loader.tsx
+++ b/frontend/src/pages/landing/Landing.loader.tsx
@@ -33,11 +33,10 @@ export const getStatusMap = async (urlSearchParams: URLSearchParams) => {
     urlSearchParams.set("ordering", "-created");
   }
   const lists = await listDestructionLists(urlSearchParams);
-  return STATUSES.reduce((acc, val) => {
-    const status = val[0] || "";
+  return STATUSES.reduce((acc, [status]) => {
     const destructionLists = lists.filter(
       (l) => STATUS_MAPPING[l.status] === status,
     );
-    return { ...acc, [status]: destructionLists };
+    return { ...acc, [status || ""]: destructionLists };
   }, {});
 };

--- a/frontend/src/pages/landing/Landing.stories.tsx
+++ b/frontend/src/pages/landing/Landing.stories.tsx
@@ -49,6 +49,7 @@ export const LandingPage: StoryObj<typeof Landing> = {
 
     const destroyedNames = MOCKS.DESTRUCTION_LISTS.response
       .filter((d) => d.status === "deleted")
+      .filter((d) => d.processingStatus === "succeeded")
       .map((d) => d.name);
     for (const name of destroyedNames) {
       const button = await within(canvasElement).findByTitle(name);

--- a/frontend/src/pages/landing/Landing.tsx
+++ b/frontend/src/pages/landing/Landing.tsx
@@ -188,7 +188,10 @@ export const Landing = () => {
       case "deleted":
         return canDownloadReport(user, list)
           ? API_BASE_URL + `/destruction-lists/${list.uuid}/download_report`
-          : undefined;
+          : list.processingStatus === "failed" &&
+              canViewDestructionList(user, list)
+            ? `/destruction-lists/${list.uuid}`
+            : undefined;
 
       default:
         return undefined;


### PR DESCRIPTION
parly fixes #733 

- [x] adjust backend to allow restart destruction if destruction is successful but processing is not
- [x] adjust backend to process destruction if destruction is successful but processing is not