### PR TITLE
[#800] Fix wrong behandelend afdeling filter name

### DIFF
--- a/backend/src/openarchiefbeheer/conf/base.py
+++ b/backend/src/openarchiefbeheer/conf/base.py
@@ -84,6 +84,14 @@ CACHES = {
             "IGNORE_EXCEPTIONS": True,
         },
     },
+    "choices_endpoints": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"redis://{config('CACHE_DEFAULT', 'localhost:6379/0')}",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "IGNORE_EXCEPTIONS": True,
+        },
+    },
 }
 
 # Geospatial libraries

--- a/backend/src/openarchiefbeheer/conf/ci.py
+++ b/backend/src/openarchiefbeheer/conf/ci.py
@@ -3,8 +3,6 @@ import warnings
 
 from .utils import config
 
-SESSION_ENGINE = "django.contrib.sessions.backends.db"
-
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SECRET_KEY", "dummy")
 # Do not log requests in CI/tests:
@@ -26,6 +24,7 @@ from .base import *  # noqa isort:skip
 E2E_PORT = config("E2E_PORT", default=8000)
 E2E_SERVE_FRONTEND = config("E2E_SERVE_FRONTEND", default=False)
 
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
 CACHES.update(
     {
         "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},

--- a/backend/src/openarchiefbeheer/conf/ci.py
+++ b/backend/src/openarchiefbeheer/conf/ci.py
@@ -24,10 +24,19 @@ from .base import *  # noqa isort:skip
 E2E_PORT = config("E2E_PORT", default=8000)
 E2E_SERVE_FRONTEND = config("E2E_SERVE_FRONTEND", default=False)
 
-SESSION_ENGINE = "django.contrib.sessions.backends.db"
+# FIXME: this matches the setting in production.
+# However, if you want to run the tests in parallel, this needs to be django.contrib.sessions.backends.db
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 CACHES.update(
     {
-        "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "default",
+        },
+        "choices_endpoints": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "choices",
+        },
         # See: https://github.com/jazzband/django-axes/blob/master/docs/configuration.rst#cache-problems
         "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
     }

--- a/backend/src/openarchiefbeheer/conf/dev.py
+++ b/backend/src/openarchiefbeheer/conf/dev.py
@@ -67,7 +67,14 @@ SESSION_ENGINE = "django.contrib.sessions.backends.db"
 # in memory cache and django-axes don't get along.
 # https://django-axes.readthedocs.io/en/latest/configuration.html#known-configuration-problems
 CACHES = {
-    "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "default",
+    },
+    "choices_endpoints": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "choices",
+    },
     "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
 }
 

--- a/backend/src/openarchiefbeheer/conf/dev.py
+++ b/backend/src/openarchiefbeheer/conf/dev.py
@@ -3,8 +3,6 @@ import warnings
 
 from .utils import config
 
-SESSION_ENGINE = "django.contrib.sessions.backends.db"
-
 os.environ.setdefault("DEBUG", "yes")
 os.environ.setdefault("ALLOWED_HOSTS", "*")
 os.environ.setdefault(

--- a/backend/src/openarchiefbeheer/config/setup_configuration/tests/test_setup_configuration.py
+++ b/backend/src/openarchiefbeheer/config/setup_configuration/tests/test_setup_configuration.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 
-from django.core.cache import cache
 from django.test import TestCase
 
 from django_setup_configuration.exceptions import ConfigurationRunFailed
 from django_setup_configuration.test_utils import execute_single_step
 from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
+
+from openarchiefbeheer.utils.tests.mixins import ClearCacheMixin
 
 from ...models import APIConfig
 from ..steps import APIConfigConfigurationStep
@@ -15,12 +16,7 @@ TEST_FILES = (Path(__file__).parent / "files").resolve()
 CONFIG_FILE_PATH = str(TEST_FILES / "setup_config_api.yaml")
 
 
-class APIConfigConfigurationStepTests(TestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.addCleanup(cache.clear)
-
+class APIConfigConfigurationStepTests(ClearCacheMixin, TestCase):
     def test_configure_api_config_create_new(self):
         service = ServiceFactory(
             slug="selectielijst",

--- a/backend/src/openarchiefbeheer/destruction/signals.py
+++ b/backend/src/openarchiefbeheer/destruction/signals.py
@@ -1,4 +1,5 @@
 import django.dispatch
+from django.core.cache import cache
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -39,6 +40,11 @@ def notify_reviewer_of_assignment(sender, assignee, **kwargs):
         return
 
     notify_reviewer(assignee.user, assignee.destruction_list)
+
+
+@receiver(post_save, sender=DestructionList)
+def clear_cache_on_save(sender: DestructionList, **kwargs):
+    cache.clear()
 
 
 @receiver(deletion_failure)

--- a/backend/src/openarchiefbeheer/destruction/signals.py
+++ b/backend/src/openarchiefbeheer/destruction/signals.py
@@ -1,5 +1,5 @@
 import django.dispatch
-from django.core.cache import cache
+from django.core.cache import caches
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -44,6 +44,7 @@ def notify_reviewer_of_assignment(sender, assignee, **kwargs):
 
 @receiver(post_save, sender=DestructionList)
 def clear_cache_on_save(sender: DestructionList, **kwargs):
+    cache = caches["choices_endpoints"]
     cache.clear()
 
 

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_635_filters_reset.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_635_filters_reset.py
@@ -106,9 +106,7 @@ class Issue635FiltersReset(GherkinLikeTestCase):
             await self.when_user_selects_filter_dropdown_by_index(
                 page, "Behandelende afdeling", 0
             )
-            await self.then.url_should_contain_text(
-                page, "behandelend_afdeling__icontains"
-            )
+            await self.then.url_should_contain_text(page, "behandelend_afdeling")
 
             # Startdatum
             await self.when_user_types_in_date(

--- a/backend/src/openarchiefbeheer/destruction/tests/test_models.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_models.py
@@ -3,7 +3,6 @@ from datetime import date, datetime
 from unittest.mock import patch
 
 from django.contrib.auth.models import Group
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
 from django.test import TestCase
@@ -21,6 +20,7 @@ from zgw_consumers.test.factories import ServiceFactory
 from openarchiefbeheer.config.models import ArchiveConfig
 from openarchiefbeheer.logging import logevent
 from openarchiefbeheer.utils.results_store import ResultStore
+from openarchiefbeheer.utils.tests.mixins import ClearCacheMixin
 from openarchiefbeheer.zaken.models import Zaak
 from openarchiefbeheer.zaken.tests.factories import ZaakFactory
 
@@ -40,12 +40,7 @@ from .factories import (
 )
 
 
-class DestructionListItemTest(TestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.addCleanup(cache.clear)
-
+class DestructionListItemTest(ClearCacheMixin, TestCase):
     def test_set_status(self):
         destruction_list = DestructionListFactory.create()
 

--- a/backend/src/openarchiefbeheer/destruction/tests/vcr/test_tasks.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/vcr/test_tasks.py
@@ -1,4 +1,3 @@
-from django.core.cache import cache
 from django.test import TestCase, override_settings, tag
 
 from freezegun import freeze_time
@@ -10,6 +9,7 @@ from zgw_consumers.test.factories import ServiceFactory
 
 from openarchiefbeheer.accounts.tests.factories import UserFactory
 from openarchiefbeheer.config.models import APIConfig, ArchiveConfig
+from openarchiefbeheer.utils.tests.mixins import ClearCacheMixin
 from openarchiefbeheer.utils.utils_decorators import reload_openzaak_fixtures
 from openarchiefbeheer.zaken.models import Zaak
 from openarchiefbeheer.zaken.tasks import retrieve_and_cache_zaken_from_openzaak
@@ -98,14 +98,7 @@ class ProcessResponseTest(VCRMixin, TestCase):
 
 
 @tag("vcr")
-class DestructionTest(VCRMixin, TestCase):
-    def setUp(self):
-        super().setUp()
-
-        cache.clear()
-
-        self.addCleanup(cache.clear)
-
+class DestructionTest(ClearCacheMixin, VCRMixin, TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()

--- a/backend/src/openarchiefbeheer/utils/tests/mixins.py
+++ b/backend/src/openarchiefbeheer/utils/tests/mixins.py
@@ -1,8 +1,10 @@
-from django.core.cache import cache
+from django.core.cache import caches
 
 
 class ClearCacheMixin:
     def setUp(self):
         super().setUp()
 
-        self.addCleanup(cache.clear)
+        for cache in caches:
+            caches[cache].clear()
+            self.addCleanup(caches[cache].clear)

--- a/backend/src/openarchiefbeheer/zaken/api/views.py
+++ b/backend/src/openarchiefbeheer/zaken/api/views.py
@@ -89,7 +89,7 @@ class InternalZaaktypenChoicesView(APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def get(self, request, *args, **kwargs):
         return self._retrieve_zaaktypen(request)
 
@@ -108,7 +108,7 @@ class InternalZaaktypenChoicesView(APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def post(self, request, *args, **kwargs):
         return self._retrieve_zaaktypen(request)
 
@@ -131,7 +131,7 @@ class ExternalZaaktypenChoicesView(APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def get(self, request, *args, **kwargs):
         results = retrieve_zaaktypen()
         zaaktypen_choices = format_zaaktype_choices(results)
@@ -184,7 +184,7 @@ class InternalSelectielijstklasseChoicesView(FilterOnZaaktypeMixin, APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def get(self, request, *args, **kwargs):
         filterset = ZaakFilterSet(data=request.query_params or request.data)
         is_valid = filterset.is_valid()
@@ -240,7 +240,7 @@ class StatustypeChoicesView(FilterOnZaaktypeMixin, APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def get(self, request, *args, **kwargs):
         query_params = self.get_query_params(request)
         results = retrieve_paginated_type("statustypen", query_params)
@@ -297,7 +297,7 @@ class InformatieobjecttypeChoicesView(FilterOnZaaktypeMixin, APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def get(self, request, *args, **kwargs):
         query_params = self.get_query_params(request)
         results = retrieve_paginated_type("informatieobjecttypen", query_params)
@@ -323,7 +323,7 @@ class ExternalResultaattypeChoicesView(FilterOnZaaktypeMixin, APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def get(self, request, *args, **kwargs):
         query_params = self.get_query_params(request)
         results = retrieve_paginated_type("resultaattypen", query_params)
@@ -347,7 +347,7 @@ class InternalResultaattypeChoicesView(APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def get(self, request, *args, **kwargs):
         filterset = ZaakFilterSet(data=request.query_params or request.data)
         is_valid = filterset.is_valid()
@@ -390,7 +390,7 @@ class BehandelendAfdelingInternalChoicesView(APIView):
             200: ChoiceSerializer(many=True),
         },
     )
-    @method_decorator(cache_page(60 * 15))
+    @method_decorator(cache_page(60 * 15, cache="choices_endpoints"))
     def get(self, request, *args, **kwargs):
         filterset = ZaakFilterSet(data=request.query_params or request.data)
         is_valid = filterset.is_valid()

--- a/backend/src/openarchiefbeheer/zaken/tests/test_serializer.py
+++ b/backend/src/openarchiefbeheer/zaken/tests/test_serializer.py
@@ -1,4 +1,3 @@
-from django.core.cache import cache
 from django.test import TestCase, tag
 
 from vcr.unittest import VCRMixin
@@ -6,20 +5,14 @@ from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
 
 from openarchiefbeheer.config.models import APIConfig
+from openarchiefbeheer.utils.tests.mixins import ClearCacheMixin
 
 from ..api.serializers import ZaakMetadataSerializer
 from .factories import ZaakFactory
 
 
 @tag("vcr")
-class ZaakSerialisersTests(VCRMixin, TestCase):
-    def setUp(self):
-        super().setUp()
-
-        cache.clear()
-
-        self.addCleanup(cache.clear)
-
+class ZaakSerialisersTests(ClearCacheMixin, VCRMixin, TestCase):
     def test_selectielijstklasse(self):
         service = ServiceFactory(
             slug="selectielijst",

--- a/backend/src/openarchiefbeheer/zaken/tests/test_tasks.py
+++ b/backend/src/openarchiefbeheer/zaken/tests/test_tasks.py
@@ -1,7 +1,6 @@
 from datetime import date
 from unittest.mock import patch
 
-from django.core.cache import cache
 from django.test import TestCase, TransactionTestCase, tag
 from django.utils.translation import gettext_lazy as _
 
@@ -15,6 +14,7 @@ from zgw_consumers.test.factories import ServiceFactory
 from openarchiefbeheer.config.models import APIConfig
 from openarchiefbeheer.destruction.tests.factories import DestructionListItemFactory
 from openarchiefbeheer.utils.tests.get_queries import executed_queries
+from openarchiefbeheer.utils.tests.mixins import ClearCacheMixin
 
 from ..models import Zaak
 from ..tasks import resync_zaken, retrieve_and_cache_zaken_from_openzaak
@@ -625,12 +625,7 @@ class RetrieveCachedZakenWithProcestypeTest(TransactionTestCase):
         )
 
 
-class RetrieveCachedZakenQueryTest(TestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.addCleanup(cache.clear)
-
+class RetrieveCachedZakenQueryTest(ClearCacheMixin, TestCase):
     @Mocker()
     def test_queries_retrieve_zaken(self, m):
         ServiceFactory.create(

--- a/backend/src/openarchiefbeheer/zaken/tests/vcr/test_views.py
+++ b/backend/src/openarchiefbeheer/zaken/tests/vcr/test_views.py
@@ -1,5 +1,3 @@
-from django.core.cache import cache
-
 from furl import furl
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -9,11 +7,12 @@ from zgw_consumers.constants import APITypes
 from zgw_consumers.test.factories import ServiceFactory
 
 from openarchiefbeheer.accounts.tests.factories import UserFactory
+from openarchiefbeheer.utils.tests.mixins import ClearCacheMixin
 
 from ...utils import retrieve_paginated_type
 
 
-class StatustypenChoicesViewTests(VCRMixin, APITestCase):
+class StatustypenChoicesViewTests(ClearCacheMixin, VCRMixin, APITestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
@@ -28,7 +27,6 @@ class StatustypenChoicesViewTests(VCRMixin, APITestCase):
     def setUp(self):
         super().setUp()
 
-        self.addCleanup(cache.clear)
         self.addCleanup(retrieve_paginated_type.cache_clear)
 
     def test_retrieve_all_choices(self):
@@ -76,7 +74,7 @@ class StatustypenChoicesViewTests(VCRMixin, APITestCase):
         )
 
 
-class ResultaattypenChoicesViewTests(VCRMixin, APITestCase):
+class ResultaattypenChoicesViewTests(ClearCacheMixin, VCRMixin, APITestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
@@ -91,7 +89,6 @@ class ResultaattypenChoicesViewTests(VCRMixin, APITestCase):
     def setUp(self):
         super().setUp()
 
-        self.addCleanup(cache.clear)
         self.addCleanup(retrieve_paginated_type.cache_clear)
 
     def test_retrieve_all_choices(self):
@@ -139,7 +136,7 @@ class ResultaattypenChoicesViewTests(VCRMixin, APITestCase):
         )
 
 
-class InformatieobjecttypenChoicesViewTests(VCRMixin, APITestCase):
+class InformatieobjecttypenChoicesViewTests(ClearCacheMixin, VCRMixin, APITestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
@@ -154,7 +151,6 @@ class InformatieobjecttypenChoicesViewTests(VCRMixin, APITestCase):
     def setUp(self):
         super().setUp()
 
-        self.addCleanup(cache.clear)
         self.addCleanup(retrieve_paginated_type.cache_clear)
 
     def test_retrieve_all_choices(self):
@@ -200,7 +196,7 @@ class InformatieobjecttypenChoicesViewTests(VCRMixin, APITestCase):
         )
 
 
-class ExternalZaaktypenChoicesViewTests(VCRMixin, APITestCase):
+class ExternalZaaktypenChoicesViewTests(ClearCacheMixin, VCRMixin, APITestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
@@ -215,7 +211,6 @@ class ExternalZaaktypenChoicesViewTests(VCRMixin, APITestCase):
     def setUp(self):
         super().setUp()
 
-        self.addCleanup(cache.clear)
         self.addCleanup(retrieve_paginated_type.cache_clear)
 
     def test_retrieve_all_choices(self):

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
 OAB_API_URL=http://localhost:8000
 OAB_API_PATH=/api/v1
 OAB_ZAAK_URL_TEMPLATE=https://www.example.com/zaken/{identificatie}
+OAB_CACHE_DISABLED=false

--- a/frontend/src/hooks/useFields.tsx
+++ b/frontend/src/hooks/useFields.tsx
@@ -217,8 +217,8 @@ export function useFields<T extends Zaak = Zaak>(
     {
       name: "Behandelende afdeling",
       type: "string",
-      filterLookup: "behandelend_afdeling__icontains",
-      filterValue: searchParams.get("behandelend_afdeling__icontains") || "",
+      filterLookup: "behandelend_afdeling",
+      filterValue: searchParams.get("behandelend_afdeling") || "",
       valueTransform: (rowData: object) => {
         const rollen = (rowData as ExpandZaak)._expand?.rollen || [];
         if (!rollen.length) return "";

--- a/frontend/src/hooks/useFields.tsx
+++ b/frontend/src/hooks/useFields.tsx
@@ -234,7 +234,7 @@ export function useFields<T extends Zaak = Zaak>(
             .join(", ")
         );
       },
-      options: behandelendAfdelingChoices,
+      options: behandelendAfdelingChoices || [],
       width: "150px",
     },
     {

--- a/frontend/src/lib/api/private.ts
+++ b/frontend/src/lib/api/private.ts
@@ -15,6 +15,7 @@ export async function listBehandelendAfdelingChoices(
   params?: URLSearchParams | Record<string, string | number | undefined>,
   signal?: AbortSignal,
 ): Promise<Option[]> {
+  const cacheParams = params2CacheKey(params || {});
   return cacheMemo(
     "listBehandelendAfdelingChoices",
     async () => {
@@ -30,7 +31,7 @@ export async function listBehandelendAfdelingChoices(
 
       return promise;
     },
-    [JSON.stringify(params)],
+    [cacheParams],
   );
 }
 

--- a/frontend/src/pages/destructionlist/create/DestructionListCreate.action.ts
+++ b/frontend/src/pages/destructionlist/create/DestructionListCreate.action.ts
@@ -3,6 +3,7 @@ import { redirect } from "react-router-dom";
 
 import { TypedAction } from "../../../hooks";
 import { createDestructionList } from "../../../lib/api/destructionLists";
+import { cacheDelete } from "../../../lib/cache/cache";
 import {
   clearZaakSelection,
   getAllZakenSelected,
@@ -63,5 +64,6 @@ export const destructionListCreateAction = async ({
   }
 
   await clearZaakSelection(DESTRUCTION_LIST_CREATE_KEY);
+  await cacheDelete("list", true); // Remove possibly outdated cached value of list API's for choices.
   return redirect("/");
 };

--- a/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
+++ b/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
@@ -76,6 +76,8 @@ export async function destructionListDeleteAction({
     }
     throw e;
   }
+
+  await cacheDelete("list", true); // Remove possibly outdated cached value of list API's for choices.
   return redirect("/");
 }
 

--- a/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
+++ b/frontend/src/pages/destructionlist/detail/DestructionListDetail.action.ts
@@ -193,7 +193,7 @@ export async function destructionListUpdateZakenAction({
     throw e;
   }
   await clearZaakSelection(storageKey);
-  await cacheDelete("listZaaktypeChoices", true); // Remove possibly outdated zaaktype cache.
+  await cacheDelete("list", true); // Remove possibly outdated cached value of list API's for choices.
   return redirect(`/destruction-lists/${params.uuid}`);
 }
 


### PR DESCRIPTION
Partially fixes #800 

This fixes the wrong name, the fix of the cache should fix the problem of the choices not being refreshed.