### PR TITLE
[#841] Update destruction list assignees

### DIFF
--- a/backend/src/openarchiefbeheer/api/tests/test_oidc_auth.py
+++ b/backend/src/openarchiefbeheer/api/tests/test_oidc_auth.py
@@ -6,7 +6,7 @@ from openarchiefbeheer.utils.tests.e2e import browser_page
 from openarchiefbeheer.utils.tests.gherkin import GherkinLikeTestCase
 
 
-@tag("e2e")
+@tag("e2e", "oidc")
 class OIDCLoginTest(GherkinLikeTestCase):
     fixtures = ["permissions.json", "oidc_config_test.json"]
 

--- a/backend/src/openarchiefbeheer/destruction/api/permissions.py
+++ b/backend/src/openarchiefbeheer/destruction/api/permissions.py
@@ -151,10 +151,6 @@ class CanAbortDestruction(permissions.BasePermission):
 
 
 class CanUpdateCoReviewers(permissions.BasePermission):
-    """
-    TODO: THIS CHECK NEETS TO BE EVALUATED ALONG WITH ITS TS COUNTERPART
-    """
-
     message = _("You are not allowed to update the co-reviewers.")
 
     def has_permission(self, request, view):

--- a/backend/src/openarchiefbeheer/destruction/api/permissions.py
+++ b/backend/src/openarchiefbeheer/destruction/api/permissions.py
@@ -124,6 +124,7 @@ class CanReassignDestructionList(permissions.BasePermission):
     def has_object_permission(self, request, view, destruction_list):
         return destruction_list.status in [
             ListStatus.new,
+            ListStatus.changes_requested,
             ListStatus.ready_to_review,
             ListStatus.ready_for_archivist,
         ]
@@ -150,6 +151,10 @@ class CanAbortDestruction(permissions.BasePermission):
 
 
 class CanUpdateCoReviewers(permissions.BasePermission):
+    """
+    TODO: THIS CHECK NEETS TO BE EVALUATED ALONG WITH ITS TS COUNTERPART
+    """
+
     message = _("You are not allowed to update the co-reviewers.")
 
     def has_permission(self, request, view):

--- a/backend/src/openarchiefbeheer/destruction/api/permissions.py
+++ b/backend/src/openarchiefbeheer/destruction/api/permissions.py
@@ -125,6 +125,7 @@ class CanReassignDestructionList(permissions.BasePermission):
         return destruction_list.status in [
             ListStatus.new,
             ListStatus.ready_to_review,
+            ListStatus.ready_for_archivist,
         ]
 
 

--- a/backend/src/openarchiefbeheer/destruction/api/serializers.py
+++ b/backend/src/openarchiefbeheer/destruction/api/serializers.py
@@ -10,7 +10,6 @@ from requests.exceptions import HTTPError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.relations import SlugRelatedField
-from typing_extensions import deprecated
 
 from openarchiefbeheer.accounts.api.serializers import UserSerializer
 from openarchiefbeheer.accounts.models import User
@@ -275,12 +274,6 @@ class UpdateAssigneeSerializer(serializers.Serializer):
             )
 
         return attrs
-
-
-@deprecated("Deprecated in favour of UpdateAssigneeSerializer")
-class ReassignementSerializer(serializers.Serializer):
-    comment = serializers.CharField(required=True, allow_blank=False)
-    assignee = ReviewerAssigneeSerializer()
 
 
 class DestructionListItemWriteSerializer(serializers.ModelSerializer):

--- a/backend/src/openarchiefbeheer/destruction/assignment_logic.py
+++ b/backend/src/openarchiefbeheer/destruction/assignment_logic.py
@@ -104,8 +104,8 @@ class ReadyForArchivist:
         destruction_list.assign(destruction_list.get_author())
 
     def reassign(self, destruction_list: "DestructionList") -> None:
-        # TODO
-        raise NotImplementedError
+        archivist = destruction_list.assignees.filter(role=ListRole.archivist).first()
+        destruction_list.assign(archivist)
 
 
 STATE_MANAGER = {

--- a/backend/src/openarchiefbeheer/destruction/constants.py
+++ b/backend/src/openarchiefbeheer/destruction/constants.py
@@ -47,3 +47,30 @@ class InternalStatus(models.TextChoices):
     processing = "processing", _("processing")
     failed = "failed", _("failed")
     succeeded = "succeeded", _("succeeded")
+
+
+MAPPING_ROLE_PERMISSIONS = {
+    ListRole.author: "accounts.can_start_destruction",
+    ListRole.main_reviewer: "accounts.can_review_destruction",
+    ListRole.co_reviewer: "accounts.can_co_review_destruction",
+    ListRole.archivist: "accounts.can_review_final_list",
+}
+
+# Mapping to check if it is allowed to change an assignee
+# based on the list status.
+# Co-reviewers are not included because they have different logic (and their separate endpoint).
+MAPPING_STATUS_ROLE_POSSIBLE_CHANGES = {
+    ListStatus.new: [ListRole.main_reviewer, ListRole.author],
+    ListStatus.ready_to_review: [ListRole.main_reviewer, ListRole.author],
+    # Challenging: the changes could have been requested by a reviewr or an archivist.
+    # We cannot decide based on the status alone.
+    ListStatus.changes_requested: [
+        ListRole.main_reviewer,
+        ListRole.archivist,
+        ListRole.author,
+    ],
+    # From internally_reviewed onward, we cannot change the reviewer (since they have nothing left to do)
+    ListStatus.internally_reviewed: [ListRole.author],
+    ListStatus.ready_for_archivist: [ListRole.archivist, ListRole.author],
+    ListStatus.ready_to_delete: [ListRole.author],
+}

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_841_reassign_when_changes_requested.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_841_reassign_when_changes_requested.py
@@ -26,6 +26,7 @@ class Issue841ReassignWhenChangesRequestedTestCase(GherkinLikeTestCase):
                 page, "Naam", "gh-841-destruction-list"
             )
             await self.when.user_fills_form_field(page, "Reviewer", str(reviewer1))
+            await self.when.user_fills_form_field(page, "Opmerking", "Description bla.")
             await self.when.user_clicks_button(page, "Vernietigingslijst opstellen", 2)
 
             await self.then.path_should_be(page, "/destruction-lists")

--- a/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_841_reassign_when_changes_requested.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/e2e/issues/test_841_reassign_when_changes_requested.py
@@ -1,0 +1,79 @@
+from django.test import tag
+
+from openarchiefbeheer.utils.tests.e2e import browser_page
+from openarchiefbeheer.utils.tests.gherkin import GherkinLikeTestCase
+
+
+@tag("e2e")
+@tag("issue")
+@tag("gh-843")
+class Issue841ReassignWhenChangesRequestedTestCase(GherkinLikeTestCase):
+    async def test_scenario_update_reviewer_when_changes_requested(self):
+        async with browser_page() as page:
+            await self.given.record_manager_exists()
+            reviewer1 = await self.given.reviewer_exists(username="reviewer1")
+            reviewer2 = await self.given.reviewer_exists(username="reviewer2")
+            await self.given.zaken_are_indexed(2)
+
+            # Record manager creates list and sends it to reviewer 1
+            await self.when.record_manager_logs_in(page)
+            await self.when.user_clicks_button(page, "Vernietigingslijst opstellen")
+            await self.when.user_clicks_checkbox(page, "(de)selecteer rij", index=0)
+            await self.when.user_clicks_button(
+                page, "Vernietigingslijst opstellen", index=1
+            )
+            await self.when.user_fills_form_field(
+                page, "Naam", "gh-841-destruction-list"
+            )
+            await self.when.user_fills_form_field(page, "Reviewer", str(reviewer1))
+            await self.when.user_clicks_button(page, "Vernietigingslijst opstellen", 2)
+
+            await self.then.path_should_be(page, "/destruction-lists")
+            await self.then.list_should_exist(page, "gh-841-destruction-list")
+
+            await self.when.record_manager_logs_in(page)
+            await self.when.user_clicks_button(page, "gh-841-destruction-list")
+            await self.when.user_clicks_button(page, "Ter beoordeling indienen")
+            await self.when.user_clicks_button(page, "Ter beoordeling indienen", 1)
+
+            await self.then.path_should_be(page, "/destruction-lists")
+
+            # Reviewer 1 rejects the list
+            await self.when.reviewer_logs_in(page, username=reviewer1.username)
+            await self.when.user_clicks_button(page, "gh-841-destruction-list")
+            await self.when.user_clicks_button(page, "Uitzonderen")
+            await self.when.user_fills_form_field(
+                page, "Reden", "Please reconsider this zaak"
+            )
+
+            await self.when.user_clicks_button(page, "Zaak uitzonderen")
+            await self.when.user_clicks_button(page, "Afwijzen")
+            await self.when.user_fills_form_field(
+                page, "Reden", "Please reconsider the zaak on this list"
+            )
+            await self.when.user_clicks_button(page, "Vernietigingslijst afwijzen")
+
+            await self.then.path_should_be(page, "/destruction-lists")
+            await self.when.user_logs_out(page)
+
+            # The record manager reassigns the reviewer and then re-submits the list.
+            await self.when.record_manager_logs_in(page)
+            await self.when.user_clicks_button(page, "gh-841-destruction-list")
+            await self.when.user_clicks_button(page, "Beoordelaar bewerken")
+            await self.when.user_fills_form_field(page, "Beoordelaar", str(reviewer2))
+            await self.when.user_fills_form_field(
+                page, "Reden", "Ik houd niet van Reviewer 1."
+            )
+            await self.when.user_clicks_button(page, "Toewijzen")
+            await self.then.page_should_contain_text(page, str(reviewer1))
+
+            await self.when.user_clicks_button(page, "Muteren")
+            await self.when.user_clicks_radio(page, "Afwijzen van het voorstel")
+            await self.when.user_fills_form_field(page, "Reden", "I like this case.")
+            await self.when.user_clicks_button(page, "muteren")
+            await self.when.user_clicks_button(page, "Opnieuw indienen")
+            await self.when.user_fills_form_field(
+                page, "Opmerking", "Let's gooo.", None, 1
+            )
+            await self.when.user_clicks_button(page, "Opnieuw indienen", 1)
+            await self.then.path_should_be(page, "/destruction-lists")

--- a/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_list_destruction.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_list_destruction.py
@@ -1,6 +1,7 @@
 from datetime import date
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.utils.translation import gettext_lazy as _
 
 import freezegun
@@ -16,6 +17,7 @@ from ..factories import DestructionListFactory, DestructionListItemFactory
 
 
 class DestructionListStartDestructionEndpointTest(APITestCase):
+    @override_settings(WAITING_PERIOD=7)
     def test_plan_destruction(self):
         record_manager = UserFactory.create(
             username="record_manager", post__can_start_destruction=True
@@ -81,6 +83,7 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
         m_delete.assert_called_once()
         self.assertEqual(m_delete.call_args_list[0].args[0].pk, destruction_list.pk)
 
+    @override_settings(WAITING_PERIOD=7)
     def test_retry_destruction_after_failure_with_planned_date_in_future_raises_error(
         self,
     ):
@@ -157,6 +160,7 @@ class DestructionListStartDestructionEndpointTest(APITestCase):
         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
         m_task.assert_not_called()
 
+    @override_settings(WAITING_PERIOD=7)
     def test_cannot_start_destruction_if_archiefactiedatum_in_the_future(self):
         record_manager = UserFactory.create(
             username="record_manager", post__can_start_destruction=True

--- a/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_reviewresponse.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_reviewresponse.py
@@ -12,7 +12,7 @@ from timeline_logger.models import TimelineLog
 
 from openarchiefbeheer.accounts.tests.factories import UserFactory
 
-from ...constants import DestructionListItemAction, ListStatus, ZaakActionType
+from ...constants import DestructionListItemAction, ListRole, ListStatus, ZaakActionType
 from ...models import ReviewItemResponse, ReviewResponse
 from ..factories import (
     DestructionListAssigneeFactory,
@@ -213,6 +213,9 @@ class ReviewResponsesViewSetTests(APITestCase):
             name="Test audittrail",
             status=ListStatus.ready_to_review,
             author=record_manager,
+        )
+        DestructionListAssigneeFactory.create(
+            user=record_manager, role=ListRole.author, destruction_list=destruction_list
         )
         record_manager_group, created = Group.objects.get_or_create(
             name="Record Manager"

--- a/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_reviewresponse.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/endpoints/test_reviewresponse.py
@@ -9,7 +9,6 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 from timeline_logger.models import TimelineLog
-from typing_extensions import deprecated
 
 from openarchiefbeheer.accounts.tests.factories import UserFactory
 
@@ -204,65 +203,6 @@ class ReviewResponsesViewSetTests(APITestCase):
                 "This user is either not allowed to update the destruction list or "
                 "the destruction list cannot currently be updated."
             ),
-        )
-
-    @deprecated("Delete in 2.0 when endpoint reassign is removed.")
-    @freezegun.freeze_time("2023-09-15T21:36:00+02:00")
-    def test_audit_log(self):
-        # Reassign
-        record_manager = UserFactory.create(post__can_start_destruction=True)
-        destruction_list = DestructionListFactory.create(
-            name="Test audittrail",
-            status=ListStatus.ready_to_review,
-            author=record_manager,
-        )
-        DestructionListAssigneeFactory.create(
-            user=record_manager, role=ListRole.author, destruction_list=destruction_list
-        )
-        record_manager_group, created = Group.objects.get_or_create(
-            name="Record Manager"
-        )
-        record_manager.groups.add(record_manager_group)
-        DestructionListAssigneeFactory.create(destruction_list=destruction_list)
-        other_reviewer = UserFactory.create(post__can_review_destruction=True)
-
-        self.client.force_authenticate(user=record_manager)
-        endpoint_reassign = reverse(
-            "api:destructionlist-reassign", kwargs={"uuid": destruction_list.uuid}
-        )
-        response = self.client.post(
-            endpoint_reassign,
-            data={
-                "assignee": {"user": other_reviewer.pk},
-                "comment": "Lorem ipsum...",
-            },
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        endpoint_audittrail = furl(reverse("api:logs-list"))
-        endpoint_audittrail.args["destruction_list"] = destruction_list.uuid
-        response_audittrail = self.client.get(endpoint_audittrail.url)
-
-        self.assertEqual(response_audittrail.status_code, status.HTTP_200_OK)
-
-        data = response_audittrail.data
-
-        self.assertEqual(data[0]["user"]["pk"], record_manager.pk)
-        self.assertEqual(
-            data[0]["timestamp"],
-            "2023-09-15T21:36:00+02:00",
-        )
-        self.assertEqual(
-            data[0]["message"].strip(), _("The destruction list was reassigned.")
-        )
-        self.assertEqual(
-            data[0]["extra_data"]["assignee"]["user"],
-            {
-                "email": other_reviewer.email,
-                "pk": other_reviewer.pk,
-                "username": other_reviewer.username,
-            },
         )
 
     @freezegun.freeze_time("2023-09-15T21:36:00+02:00")

--- a/backend/src/openarchiefbeheer/destruction/tests/test_assignement_logic.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_assignement_logic.py
@@ -276,3 +276,17 @@ class AssignementLogicTest(TestCase):
 
         self.assertEqual(destruction_list.status, ListStatus.ready_for_archivist)
         self.assertEqual(destruction_list.assignee, archivist.user)
+
+    def test_reassign_archivist_when_assigned(self):
+        destruction_list = DestructionListFactory.create(
+            status=ListStatus.ready_for_archivist, assignee=None
+        )
+        archivist = DestructionListAssigneeFactory.create(
+            role=ListRole.archivist, destruction_list=destruction_list
+        )
+
+        destruction_list.reassign()
+
+        destruction_list.refresh_from_db()
+
+        self.assertEqual(destruction_list.assignee, archivist.user)

--- a/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 from timeline_logger.models import TimelineLog
+from typing_extensions import deprecated
 
 from openarchiefbeheer.accounts.tests.factories import UserFactory
 from openarchiefbeheer.config.models import ArchiveConfig
@@ -401,6 +402,7 @@ class DestructionListViewSetTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @deprecated("Delete in 2.0 when endpoint reassign is removed.")
     def test_cannot_reassign_destruction_list_if_not_record_manager(self):
         not_record_manager = UserFactory.create(post__can_start_destruction=False)
         destruction_list = DestructionListFactory.create(
@@ -424,6 +426,36 @@ class DestructionListViewSetTest(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_cannot_reassign_destruction_list_if_not_record_manager_update_assignee(
+        self,
+    ):
+        not_record_manager = UserFactory.create(post__can_start_destruction=False)
+        destruction_list = DestructionListFactory.create(
+            status=ListStatus.ready_to_review,
+        )
+        DestructionListAssigneeFactory.create_batch(
+            2, destruction_list=destruction_list
+        )
+        other_reviewers = UserFactory.create_batch(2, post__can_review_destruction=True)
+
+        self.client.force_authenticate(user=not_record_manager)
+        endpoint = reverse(
+            "api:destructionlist-update-assignee",
+            kwargs={"uuid": destruction_list.uuid},
+        )
+        response = self.client.post(
+            endpoint,
+            data={
+                "assignee": {
+                    "user": other_reviewers[0].pk,
+                    "role": ListRole.main_reviewer,
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @deprecated("Delete in 2.0 when endpoint reassign is removed.")
     def test_cannot_reassign_destruction_list_without_comment(self):
         record_manager = UserFactory.create(post__can_start_destruction=True)
         reviewer = UserFactory.create(post__can_review_destruction=True)
@@ -452,6 +484,36 @@ class DestructionListViewSetTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["comment"][0], _("This field is required."))
 
+    def test_cannot_reassign_destruction_list_without_comment_update_assignee(self):
+        record_manager = UserFactory.create(post__can_start_destruction=True)
+        reviewer = UserFactory.create(post__can_review_destruction=True)
+        destruction_list = DestructionListFactory.create(
+            author=record_manager,
+            status=ListStatus.new,
+        )
+        DestructionListAssigneeFactory.create(
+            user=reviewer, destruction_list=destruction_list
+        )
+
+        self.client.force_authenticate(user=record_manager)
+        endpoint = reverse(
+            "api:destructionlist-update-assignee",
+            kwargs={"uuid": destruction_list.uuid},
+        )
+        response = self.client.post(
+            endpoint,
+            data={
+                "assignees": [
+                    {"user": reviewer.pk, "role": ListRole.main_reviewer},
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["comment"][0], _("This field is required."))
+
+    @deprecated("Delete in 2.0 when endpoint reassign is removed.")
     def test_cannot_reassign_destruction_list_with_empty_comment(self):
         record_manager1 = UserFactory.create(post__can_start_destruction=True)
         reviewer = DestructionListAssigneeFactory.create(
@@ -484,6 +546,40 @@ class DestructionListViewSetTest(APITestCase):
             response.json()["comment"][0], _("This field may not be blank.")
         )
 
+    def test_cannot_reassign_destruction_list_with_empty_comment_update_assignee(self):
+        record_manager1 = UserFactory.create(post__can_start_destruction=True)
+        reviewer = DestructionListAssigneeFactory.create(
+            user__post__can_review_destruction=True
+        )
+
+        destruction_list = DestructionListFactory.create(
+            name="A test list",
+            contains_sensitive_info=True,
+            author=record_manager1,
+            status=ListStatus.new,
+        )
+        destruction_list.assignees.set([reviewer])
+
+        self.client.force_authenticate(user=record_manager1)
+        endpoint = reverse(
+            "api:destructionlist-update-assignee",
+            kwargs={"uuid": destruction_list.uuid},
+        )
+        response = self.client.post(
+            endpoint,
+            data={
+                "assignees": {"user": reviewer.pk, "role": ListRole.main_reviewer},
+                "comment": " ",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["comment"][0], _("This field may not be blank.")
+        )
+
+    @deprecated("Delete in 2.0 when endpoint reassign is removed.")
     def test_cannot_reassign_destruction_list_with_author_as_reviewer(self):
         record_manager = UserFactory.create(
             post__can_start_destruction=True, post__can_review_destruction=True
@@ -519,6 +615,45 @@ class DestructionListViewSetTest(APITestCase):
             _("The author of a list cannot also be a reviewer."),
         )
 
+    def test_cannot_reassign_destruction_list_with_author_as_reviewer_update_assignee(
+        self,
+    ):
+        record_manager = UserFactory.create(
+            post__can_start_destruction=True, post__can_review_destruction=True
+        )
+        destruction_list = DestructionListFactory.create(
+            name="A test list",
+            contains_sensitive_info=True,
+            author=record_manager,
+            status=ListStatus.new,
+        )
+        DestructionListAssigneeFactory.create(
+            destruction_list=destruction_list, user=record_manager, role=ListRole.author
+        )
+
+        self.client.force_authenticate(user=record_manager)
+        endpoint = reverse(
+            "api:destructionlist-update-assignee",
+            kwargs={"uuid": destruction_list.uuid},
+        )
+        response = self.client.post(
+            endpoint,
+            data={
+                "assignee": {"user": record_manager.pk, "role": ListRole.main_reviewer},
+                "comment": "comment",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["assignee"]["user"][0],
+            _(
+                "The chosen user has already had an incompatible role in this destruction list."
+            ),
+        )
+
+    @deprecated("Delete in 2.0 when endpoint reassign is removed.")
     def test_reassign_destruction_list(self):
         record_manager = UserFactory.create(post__can_start_destruction=True)
         reviewer = UserFactory.create(post__can_review_destruction=True)
@@ -559,6 +694,55 @@ class DestructionListViewSetTest(APITestCase):
 
         log_entry = TimelineLog.objects.filter(
             template__icontains="destruction_list_reassigned"
+        )[0]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            log_entry.extra_data["assignee"]["user"]["pk"], other_reviewer.pk
+        )
+        self.assertEqual(log_entry.extra_data["comment"], "Lorem ipsum...")
+
+    def test_reassign_destruction_list_update_assignee(self):
+        record_manager = UserFactory.create(post__can_start_destruction=True)
+        reviewer = UserFactory.create(post__can_review_destruction=True)
+        destruction_list = DestructionListFactory.create(
+            status=ListStatus.ready_to_review, author=record_manager, assignee=reviewer
+        )
+        DestructionListAssigneeFactory.create(
+            destruction_list=destruction_list, user=record_manager, role=ListRole.author
+        )
+        DestructionListAssigneeFactory.create(
+            destruction_list=destruction_list,
+            user=reviewer,
+            role=ListRole.main_reviewer,
+        )
+
+        other_reviewer = UserFactory.create(post__can_review_destruction=True)
+
+        self.client.force_authenticate(user=record_manager)
+        endpoint = reverse(
+            "api:destructionlist-update-assignee",
+            kwargs={"uuid": destruction_list.uuid},
+        )
+        response = self.client.post(
+            endpoint,
+            data={
+                "assignee": {"user": other_reviewer.pk, "role": ListRole.main_reviewer},
+                "comment": "Lorem ipsum...",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        new_assignees = DestructionListAssignee.objects.filter(
+            destruction_list=destruction_list, role=ListRole.main_reviewer
+        ).order_by("pk")
+
+        self.assertEqual(new_assignees[0].user, other_reviewer)
+
+        log_entry = TimelineLog.objects.filter(
+            template__icontains="destruction_list_updated_assignees"
         )[0]
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
+++ b/backend/src/openarchiefbeheer/destruction/tests/test_endpoints.py
@@ -494,6 +494,9 @@ class DestructionListViewSetTest(APITestCase):
             author=record_manager,
             status=ListStatus.new,
         )
+        DestructionListAssigneeFactory.create(
+            destruction_list=destruction_list, user=record_manager, role=ListRole.author
+        )
 
         self.client.force_authenticate(user=record_manager)
         endpoint = reverse(
@@ -518,10 +521,19 @@ class DestructionListViewSetTest(APITestCase):
 
     def test_reassign_destruction_list(self):
         record_manager = UserFactory.create(post__can_start_destruction=True)
+        reviewer = UserFactory.create(post__can_review_destruction=True)
         destruction_list = DestructionListFactory.create(
-            status=ListStatus.ready_to_review, author=record_manager
+            status=ListStatus.ready_to_review, author=record_manager, assignee=reviewer
         )
-        DestructionListAssigneeFactory.create(destruction_list=destruction_list)
+        DestructionListAssigneeFactory.create(
+            destruction_list=destruction_list, user=record_manager, role=ListRole.author
+        )
+        DestructionListAssigneeFactory.create(
+            destruction_list=destruction_list,
+            user=reviewer,
+            role=ListRole.main_reviewer,
+        )
+
         other_reviewer = UserFactory.create(post__can_review_destruction=True)
 
         self.client.force_authenticate(user=record_manager)

--- a/backend/src/openarchiefbeheer/logging/logevent.py
+++ b/backend/src/openarchiefbeheer/logging/logevent.py
@@ -3,6 +3,7 @@ import traceback
 from django.db.models import Max, Min, Model
 
 from timeline_logger.models import TimelineLog
+from typing_extensions import deprecated
 
 from openarchiefbeheer.accounts.api.serializers import UserSerializer
 from openarchiefbeheer.accounts.models import User
@@ -135,6 +136,9 @@ def destruction_list_updated(destruction_list: DestructionList, user: User) -> N
     _create_log(model=destruction_list, event="destruction_list_updated", user=user)
 
 
+@deprecated(
+    "Deprecated in favour of destruction_list_updated_assignees. Will be removed in 2.0"
+)
 def destruction_list_reassigned(
     destruction_list: DestructionList,
     assignee: DestructionListAssignee,
@@ -144,6 +148,29 @@ def destruction_list_reassigned(
     _create_log(
         model=destruction_list,
         event="destruction_list_reassigned",
+        user=user,
+        extra_data={
+            "assignee": {
+                "user": {
+                    "pk": assignee.user.pk,
+                    "email": assignee.user.email,
+                    "username": assignee.user.username,
+                },
+            },
+            "comment": comment,
+        },
+    )
+
+
+def destruction_list_updated_assignees(
+    destruction_list: DestructionList,
+    assignee: DestructionListAssignee,
+    comment: str,
+    user: User,
+):
+    _create_log(
+        model=destruction_list,
+        event="destruction_list_updated_assignees",
         user=user,
         extra_data={
             "assignee": {

--- a/backend/src/openarchiefbeheer/logging/logevent.py
+++ b/backend/src/openarchiefbeheer/logging/logevent.py
@@ -3,7 +3,6 @@ import traceback
 from django.db.models import Max, Min, Model
 
 from timeline_logger.models import TimelineLog
-from typing_extensions import deprecated
 
 from openarchiefbeheer.accounts.api.serializers import UserSerializer
 from openarchiefbeheer.accounts.models import User
@@ -134,32 +133,6 @@ def destruction_list_review_response_processed(
 
 def destruction_list_updated(destruction_list: DestructionList, user: User) -> None:
     _create_log(model=destruction_list, event="destruction_list_updated", user=user)
-
-
-@deprecated(
-    "Deprecated in favour of destruction_list_updated_assignees. Will be removed in 2.0"
-)
-def destruction_list_reassigned(
-    destruction_list: DestructionList,
-    assignee: DestructionListAssignee,
-    comment: str,
-    user: User,
-) -> None:
-    _create_log(
-        model=destruction_list,
-        event="destruction_list_reassigned",
-        user=user,
-        extra_data={
-            "assignee": {
-                "user": {
-                    "pk": assignee.user.pk,
-                    "email": assignee.user.email,
-                    "username": assignee.user.username,
-                },
-            },
-            "comment": comment,
-        },
-    )
 
 
 def destruction_list_updated_assignees(

--- a/backend/src/openarchiefbeheer/logging/templates/logging/destruction_list_updated_assignees.txt
+++ b/backend/src/openarchiefbeheer/logging/templates/logging/destruction_list_updated_assignees.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% translate "The destruction lists assignees were updated." %}

--- a/frontend/.storybook/mockData.ts
+++ b/frontend/.storybook/mockData.ts
@@ -1,6 +1,7 @@
 import {
   FIXTURE_DESTRUCTION_LIST,
   FIXTURE_SELECTIELIJSTKLASSE_CHOICES,
+  archivistFactory,
   auditLogFactory,
   coReviewsFactory,
   destructionListAssigneesFactory,
@@ -152,6 +153,12 @@ export const MOCKS = {
     method: "GET",
     status: 200,
     response: [recordManagerFactory()],
+  },
+  ARCHIVISTS: {
+    url: "http://localhost:8000/api/v1/users?role=archivist",
+    method: "GET",
+    status: 200,
+    response: [archivistFactory()],
   },
   REVIEWERS: {
     url: "http://localhost:8000/api/v1/users?role=main_reviewer",

--- a/frontend/src/components/DestructionListArchivist/DestructionListArchivist.stories.tsx
+++ b/frontend/src/components/DestructionListArchivist/DestructionListArchivist.stories.tsx
@@ -1,0 +1,58 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import {
+  ClearSessionStorageDecorator,
+  ReactRouterDecorator,
+} from "../../../.storybook/decorators";
+import { MOCKS } from "../../../.storybook/mockData";
+import {
+  archivistFactory,
+  destructionListFactory,
+  recordManagerFactory,
+} from "../../fixtures";
+import { DestructionListArchivist } from "./DestructionListArchivist";
+
+const RECORD_MANAGER = recordManagerFactory({
+  pk: 1,
+  username: "record_manager",
+});
+const REVIEWER = recordManagerFactory({ pk: 2, username: "reviewer" });
+const ARCHIVIST = archivistFactory({ pk: 1, username: "archivist1" });
+
+const meta: Meta<typeof DestructionListArchivist> = {
+  title: "Components/DestructionListArchivist",
+  component: DestructionListArchivist,
+  decorators: [ClearSessionStorageDecorator, ReactRouterDecorator],
+  parameters: {
+    mockData: [
+      MOCKS.HEALTH_CHECK,
+      MOCKS.ARCHIVISTS,
+      MOCKS.OIDC_INFO,
+      MOCKS.INTERNAL_SELECTIE_LIJST_CHOICES,
+      {
+        url: "http://localhost:8000/api/v1/whoami/",
+        method: "GET",
+        status: 200,
+        response: RECORD_MANAGER,
+      },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReadyForArchivist: Story = {
+  args: {
+    destructionList: destructionListFactory({
+      author: RECORD_MANAGER,
+      assignee: ARCHIVIST,
+      status: "ready_for_archivist",
+      assignees: [
+        { user: RECORD_MANAGER, role: "author" },
+        { user: REVIEWER, role: "main_reviewer" },
+        { user: ARCHIVIST, role: "archivist" },
+      ],
+    }),
+  },
+};

--- a/frontend/src/components/DestructionListArchivist/DestructionListArchivist.stories.tsx
+++ b/frontend/src/components/DestructionListArchivist/DestructionListArchivist.stories.tsx
@@ -1,10 +1,12 @@
 import { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "@storybook/test";
 
 import {
   ClearSessionStorageDecorator,
   ReactRouterDecorator,
 } from "../../../.storybook/decorators";
 import { MOCKS } from "../../../.storybook/mockData";
+import { fillForm } from "../../../.storybook/playFunctions";
 import {
   archivistFactory,
   destructionListFactory,
@@ -54,5 +56,71 @@ export const ReadyForArchivist: Story = {
         { user: ARCHIVIST, role: "archivist" },
       ],
     }),
+  },
+  play: async ({ context }) => {
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    const editButton = await within(context.canvasElement).findByRole(
+      "button",
+      {
+        name: "Archivaris bewerken",
+      },
+    );
+    expect(editButton).toBeInTheDocument();
+
+    await userEvent.click(editButton);
+    const dialog = await within(context.canvasElement).findByRole("dialog");
+    const form = dialog.querySelector("form");
+    await fillForm({
+      ...context,
+      parameters: {
+        fillForm: {
+          form: form,
+          formValues: {
+            Archivaris: "Archi Varis (Archivaris)",
+            Reden: "Tada",
+          },
+          submitForm: true,
+        },
+      },
+    });
+  },
+};
+
+export const ReadyForArchivistSeenByArchivist: Story = {
+  args: {
+    destructionList: destructionListFactory({
+      author: RECORD_MANAGER,
+      assignee: ARCHIVIST,
+      status: "ready_for_archivist",
+      assignees: [
+        { user: RECORD_MANAGER, role: "author" },
+        { user: REVIEWER, role: "main_reviewer" },
+        { user: ARCHIVIST, role: "archivist" },
+      ],
+    }),
+  },
+  parameters: {
+    mockData: [
+      MOCKS.HEALTH_CHECK,
+      MOCKS.ARCHIVISTS,
+      MOCKS.OIDC_INFO,
+      MOCKS.INTERNAL_SELECTIE_LIJST_CHOICES,
+      {
+        url: "http://localhost:8000/api/v1/whoami/",
+        method: "GET",
+        status: 200,
+        response: ARCHIVIST,
+      },
+    ],
+  },
+  play: async ({ context }) => {
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    const editButton = await within(context.canvasElement).queryByRole(
+      "button",
+      {
+        name: "Archivaris bewerken",
+      },
+    );
+    expect(editButton).not.toBeInTheDocument();
   },
 };

--- a/frontend/src/components/DestructionListArchivist/DestructionListArchivist.tsx
+++ b/frontend/src/components/DestructionListArchivist/DestructionListArchivist.tsx
@@ -19,10 +19,7 @@ import {
   DestructionList,
   updateAssigneeDestructionList,
 } from "../../lib/api/destructionLists";
-import {
-  canReassignDestructionList,
-  canStartDestructionList,
-} from "../../lib/auth/permissions";
+import { canReassignDestructionList } from "../../lib/auth/permissions";
 import { collectErrors } from "../../lib/format/error";
 import { formatUser } from "../../lib/format/user";
 
@@ -90,9 +87,6 @@ export function DestructionListArchivist({
       value: assignArchivistFormState.comment,
     };
 
-    if (!user || !canStartDestructionList(user)) {
-      return [commentField];
-    }
     return [archivistField, commentField];
   }, [assignArchivistModalOpenState, assignArchivistFormState.archivist]);
 

--- a/frontend/src/components/DestructionListArchivist/DestructionListArchivist.tsx
+++ b/frontend/src/components/DestructionListArchivist/DestructionListArchivist.tsx
@@ -1,0 +1,193 @@
+import {
+  AttributeTable,
+  Button,
+  FormField,
+  P,
+  Solid,
+  TypedSerializedFormData,
+  useAlert,
+  useFormDialog,
+  validateForm,
+} from "@maykin-ui/admin-ui";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigation, useRevalidator } from "react-router-dom";
+
+import { useDataFetcher } from "../../hooks/useDataFetcher";
+import { listArchivists } from "../../lib/api/archivist";
+import { whoAmI } from "../../lib/api/auth";
+import {
+  DestructionList,
+  updateAssigneeDestructionList,
+} from "../../lib/api/destructionLists";
+import {
+  canReassignDestructionList,
+  canStartDestructionList,
+} from "../../lib/auth/permissions";
+import { collectErrors } from "../../lib/format/error";
+import { formatUser } from "../../lib/format/user";
+
+export type DestructionListArchivistProps = {
+  destructionList: DestructionList;
+};
+
+export type DestructionListArchivistFormType = {
+  archivist: string;
+  comment: string;
+};
+
+export function DestructionListArchivist({
+  destructionList,
+}: DestructionListArchivistProps) {
+  const alert = useAlert();
+  const { state } = useNavigation();
+  const revalidator = useRevalidator();
+
+  const formDialog = useFormDialog<DestructionListArchivistFormType>();
+  const { data: archivarissen } = useDataFetcher(
+    listArchivists,
+    {
+      errorMessage:
+        "Er is een fout opgetreden bij het ophalen van de archivarissen!",
+      initialState: [],
+    },
+    [],
+  );
+  const { data: user } = useDataFetcher(
+    (signal) => whoAmI(signal),
+    {
+      errorMessage:
+        "Er is een fout opgetreden bij het ophalen van de huidige gebruiker!",
+      initialState: null,
+    },
+    [],
+  );
+  const [assignArchivistModalOpenState, setAssignArchivistModalOpenState] =
+    useState(false);
+  const [assignArchivistFormState, setAssignArchivistFormState] = useState<{
+    archivist: string;
+    comment: string;
+  }>({ archivist: "", comment: "" });
+
+  const fields = useMemo<FormField[]>(() => {
+    const archivistField = {
+      label: "Archivaris",
+      name: "archivist",
+      type: "string",
+      options: archivarissen.map((u) => ({
+        label: formatUser(u),
+        value: u.pk,
+      })),
+      required: true,
+      value: assignArchivistFormState.archivist,
+    };
+
+    const commentField = {
+      autoFocus: true,
+      label: "Reden",
+      name: "comment",
+      type: "text",
+      required: true,
+      value: assignArchivistFormState.comment,
+    };
+
+    if (!user || !canStartDestructionList(user)) {
+      return [commentField];
+    }
+    return [archivistField, commentField];
+  }, [assignArchivistModalOpenState, assignArchivistFormState.archivist]);
+
+  const handleValidate = (values: TypedSerializedFormData) => {
+    const _values = Object.assign({ ...assignArchivistFormState }, values);
+    if (Object.keys(_values).length) {
+      setAssignArchivistFormState(_values as typeof assignArchivistFormState);
+    }
+    return validateForm(_values, fields);
+  };
+
+  const handleSubmit = (data: DestructionListArchivistFormType) => {
+    const { archivist, comment } = data;
+    setAssignArchivistModalOpenState(false);
+
+    updateAssigneeDestructionList(destructionList.uuid, {
+      assignee: { user: Number(archivist), role: "archivist" },
+      comment: String(comment),
+    })
+      .catch(async (e) => {
+        console.error(e);
+        try {
+          const data = await e.json();
+          const errors = collectErrors(data).join("\n");
+          alert("Foutmelding", data.detail || errors, "Ok");
+        } catch {
+          alert(
+            "Foutmelding",
+            "Er is een fout opgetreden bij het bewerken van de archivaris!",
+            "Ok",
+          );
+          return;
+        }
+      })
+      .then(() => revalidator.revalidate());
+  };
+
+  useEffect(() => {
+    formDialog(
+      "Archivaris toewijzen",
+      null,
+      fields,
+      "Toewijzen",
+      "Annuleren",
+      handleSubmit,
+      () => setAssignArchivistModalOpenState(false),
+      {
+        allowClose: true,
+        open: assignArchivistModalOpenState,
+        onClose: () => setAssignArchivistModalOpenState(false),
+      },
+      {
+        validate: handleValidate,
+      },
+    );
+  }, [assignArchivistModalOpenState, JSON.stringify(fields)]);
+
+  const assignedArchivist = destructionList.assignees.find(
+    (assignee) => assignee.role === "archivist",
+  );
+
+  return (
+    <>
+      {assignedArchivist && (
+        <AttributeTable
+          compact
+          labeledObject={{
+            reviewer: {
+              label: "Archivaris",
+              value: (
+                <P>
+                  {formatUser(assignedArchivist.user)}
+                  {user &&
+                    canReassignDestructionList(user, destructionList) && (
+                      <>
+                        &nbsp;
+                        <Button
+                          aria-label="Archivaris bewerken"
+                          disabled={
+                            state === "loading" || state === "submitting"
+                          }
+                          size="xs"
+                          variant="secondary"
+                          onClick={() => setAssignArchivistModalOpenState(true)}
+                        >
+                          <Solid.PencilIcon />
+                        </Button>
+                      </>
+                    )}
+                </P>
+              ),
+            },
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/DestructionListArchivist/index.ts
+++ b/frontend/src/components/DestructionListArchivist/index.ts
@@ -1,0 +1,1 @@
+export * from "./DestructionListArchivist";

--- a/frontend/src/components/DestructionListReviewer/DestructionListReviewer.stories.tsx
+++ b/frontend/src/components/DestructionListReviewer/DestructionListReviewer.stories.tsx
@@ -79,6 +79,12 @@ const meta: Meta<typeof DestructionListReviewerComponent> = {
           },
         ],
       },
+      {
+        url: "http://localhost:8000/api/v1/whoami/",
+        method: "GET",
+        status: 200,
+        response: RECORD_MANAGER,
+      },
     ],
   },
 };
@@ -112,7 +118,12 @@ const assertEditButton: PlayFunctionWithReturnValue<
 };
 
 export const UserCannotReassignReviewer: Story = {
-  args: { destructionList: destructionListFactory({ author: RECORD_MANAGER }) },
+  args: {
+    destructionList: destructionListFactory({
+      author: RECORD_MANAGER,
+      status: "internally_reviewed",
+    }),
+  },
   play: async (context) => {
     await assertEditButton({
       ...context,

--- a/frontend/src/components/DestructionListReviewer/DestructionListReviewer.stories.tsx
+++ b/frontend/src/components/DestructionListReviewer/DestructionListReviewer.stories.tsx
@@ -366,7 +366,7 @@ export const ReassignDestructionListErrorShowsErrorMessage: Story = {
         response: [coReviewFactory({ author: REVIEWER2 })],
       },
       {
-        url: "http://localhost:8000/api/v1/destruction-lists/00000000-0000-0000-0000-000000000000/reassign/",
+        url: "http://localhost:8000/api/v1/destruction-lists/00000000-0000-0000-0000-000000000000/update_assignee/",
         method: "POST",
         status: 400,
         response: {

--- a/frontend/src/components/DestructionListReviewer/DestructionListReviewer.tsx
+++ b/frontend/src/components/DestructionListReviewer/DestructionListReviewer.tsx
@@ -20,7 +20,7 @@ import {
   DestructionList,
   DestructionListAssignee,
   listDestructionListCoReviewers,
-  reassignDestructionList,
+  updateAssigneeDestructionList,
   updateCoReviewers,
 } from "../../lib/api/destructionLists";
 import { listCoReviewers, listReviewers } from "../../lib/api/reviewers";
@@ -203,8 +203,8 @@ export function DestructionListReviewer({
     }
 
     if (reviewer) {
-      const promise = reassignDestructionList(destructionList.uuid, {
-        assignee: { user: Number(reviewer) },
+      const promise = updateAssigneeDestructionList(destructionList.uuid, {
+        assignee: { user: Number(reviewer), role: "main_reviewer" },
         comment: String(comment),
       }).catch(async (e) => {
         console.error(e);

--- a/frontend/src/components/DestructionListReviewer/DestructionListReviewer.tsx
+++ b/frontend/src/components/DestructionListReviewer/DestructionListReviewer.tsx
@@ -357,6 +357,11 @@ export function DestructionListReviewer({
     );
   }, [assignCoReviewerModalOpenState, JSON.stringify(fields)]);
 
+  const canUpdateReviewerOrCoreviewers =
+    user &&
+    (canReassignDestructionList(user, destructionList) ||
+      canUpdateCoReviewers(user, destructionList));
+
   return (
     <>
       {assignedMainReviewer && (
@@ -369,25 +374,24 @@ export function DestructionListReviewer({
                 value: (
                   <P>
                     {formatUser(assignedMainReviewer.user)}
-                    {user &&
-                      canReassignDestructionList(user, destructionList) && (
-                        <>
-                          &nbsp;
-                          <Button
-                            aria-label="Beoordelaar bewerken"
-                            disabled={
-                              state === "loading" || state === "submitting"
-                            }
-                            size="xs"
-                            variant="secondary"
-                            onClick={() =>
-                              setAssignCoReviewerModalOpenState(true)
-                            }
-                          >
-                            <Solid.PencilIcon />
-                          </Button>
-                        </>
-                      )}
+                    {user && canUpdateReviewerOrCoreviewers && (
+                      <>
+                        &nbsp;
+                        <Button
+                          aria-label="Beoordelaar bewerken"
+                          disabled={
+                            state === "loading" || state === "submitting"
+                          }
+                          size="xs"
+                          variant="secondary"
+                          onClick={() =>
+                            setAssignCoReviewerModalOpenState(true)
+                          }
+                        >
+                          <Solid.PencilIcon />
+                        </Button>
+                      </>
+                    )}
                   </P>
                 ),
               },

--- a/frontend/src/components/DestructionListToolbar/DestructionListToolbar.tsx
+++ b/frontend/src/components/DestructionListToolbar/DestructionListToolbar.tsx
@@ -137,7 +137,7 @@ export function DestructionListToolbar({
   }, [collapsedState]);
 
   /*
-  If the list already has a DestructionListAssignee with role archivist, then they must have already 
+  If the list already has a DestructionListAssignee with role archivist, then it must have already 
   gone through the reviewer round. So it should not be possible to update the reviewer.
   */
   const destructionListHasArchivistAssigned =

--- a/frontend/src/components/DestructionListToolbar/DestructionListToolbar.tsx
+++ b/frontend/src/components/DestructionListToolbar/DestructionListToolbar.tsx
@@ -37,7 +37,10 @@ import {
 import {
   REVIEW_DECISION_LEVEL_MAPPING,
   REVIEW_DECISION_MAPPING,
+  STATUSES_ELIGIBLE_FOR_CHANGING_ARCHIVIST,
+  STATUSES_ELIGIBLE_FOR_CHANGING_REVIEWER,
 } from "../../pages/constants";
+import { DestructionListArchivist } from "../DestructionListArchivist/DestructionListArchivist";
 import {
   DestructionListAuditLogDetails,
   DestructionListAuditLogHistory,
@@ -133,6 +136,23 @@ export function DestructionListToolbar({
     setPreference<boolean>("destructionListToolbarCollapsed", collapsedState);
   }, [collapsedState]);
 
+  /*
+  If the list already has a DestructionListAssignee with role archivist, then they must have already 
+  gone through the reviewer round. So it should not be possible to update the reviewer.
+  */
+  const destructionListHasArchivistAssigned =
+    destructionList &&
+    destructionList.assignees.find((assignee) => assignee.role == "archivist");
+
+  const shouldShowReviewer =
+    destructionList &&
+    STATUSES_ELIGIBLE_FOR_CHANGING_REVIEWER.includes(destructionList.status) &&
+    !destructionListHasArchivistAssigned;
+  const shouldShowArchivist =
+    destructionList &&
+    STATUSES_ELIGIBLE_FOR_CHANGING_ARCHIVIST.includes(destructionList.status) &&
+    destructionListHasArchivistAssigned;
+
   const properties = (
     <Body>
       <Grid>
@@ -163,9 +183,15 @@ export function DestructionListToolbar({
           </Column>
         )}
 
-        {destructionList && (
+        {shouldShowReviewer && (
           <Column span={3}>
             <DestructionListReviewer destructionList={destructionList} />
+          </Column>
+        )}
+
+        {shouldShowArchivist && (
+          <Column span={3}>
+            <DestructionListArchivist destructionList={destructionList} />
           </Column>
         )}
 

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -3,3 +3,4 @@ export * from "./DestructionListReviewer";
 export * from "./DestructionListToolbar";
 export * from "./DestructionListStatusBadge";
 export * from "./ProcessingStatusBadge";
+export * from "./DestructionListArchivist";

--- a/frontend/src/fixtures/user.ts
+++ b/frontend/src/fixtures/user.ts
@@ -28,7 +28,7 @@ const FIXTURE_RECORD_MANAGER: User = {
   role: {
     canStartDestruction: true,
     canReviewDestruction: false,
-    canCoReviewDestruction: true,
+    canCoReviewDestruction: false,
     canReviewFinalList: false,
     canConfigureApplication: false,
   },

--- a/frontend/src/lib/api/destructionLists.test.ts
+++ b/frontend/src/lib/api/destructionLists.test.ts
@@ -18,7 +18,7 @@ import {
   listDestructionLists,
   markDestructionListAsFinal,
   markDestructionListAsReadyToReview,
-  reassignDestructionList,
+  updateAssigneeDestructionList,
   updateCoReviewers,
   updateDestructionList,
 } from "./destructionLists";
@@ -424,13 +424,13 @@ describe("reassignDestructionList", () => {
   it("should return response on success", async () => {
     mockResponseOnce(
       "post",
-      "http://localhost:8000/api/v1/destruction-lists/00000000-0000-0000-0000-000000000000/reassign/",
+      "http://localhost:8000/api/v1/destruction-lists/00000000-0000-0000-0000-000000000000/update_assignee/",
       {},
     );
 
     await expect(
-      reassignDestructionList("00000000-0000-0000-0000-000000000000", {
-        assignee: { user: 2 },
+      updateAssigneeDestructionList("00000000-0000-0000-0000-000000000000", {
+        assignee: { user: 2, role: "main_reviewer" },
         comment: "",
       }),
     ).resolves.toBeTruthy();
@@ -439,12 +439,12 @@ describe("reassignDestructionList", () => {
   it("should throw an error on failure", async () => {
     mockRejectOnce(
       "post",
-      "http://localhost:8000/api/v1/destruction-lists/00000000-0000-0000-0000-000000000000/reassign/",
+      "http://localhost:8000/api/v1/destruction-lists/00000000-0000-0000-0000-000000000000/update_assignee/",
     );
 
     await expect(
-      reassignDestructionList("00000000-0000-0000-0000-000000000000", {
-        assignee: { user: 2 },
+      updateAssigneeDestructionList("00000000-0000-0000-0000-000000000000", {
+        assignee: { user: 2, role: "main_reviewer" },
         comment: "",
       }),
     ).rejects.toThrow();

--- a/frontend/src/lib/api/destructionLists.ts
+++ b/frontend/src/lib/api/destructionLists.ts
@@ -23,9 +23,11 @@ export type DestructionList = {
   uuid: string;
 };
 
+export type ListRole = "main_reviewer" | "co_reviewer" | "author" | "archivist";
+
 export type DestructionListAssignee = {
   user: User;
-  role?: "main_reviewer" | "co_reviewer" | "author" | "archivist";
+  role?: ListRole;
 };
 
 // An array to be used in various parts of the application.
@@ -42,6 +44,18 @@ export const DESTRUCTION_LIST_STATUSES = [
 // Inferring the type of the array, so that we don't have to repeat the same.
 export type DestructionListStatus = (typeof DESTRUCTION_LIST_STATUSES)[number];
 
+// TODO: Is this correct? Shouldn't this have the keys:
+// add,
+// remove,
+// uuid,
+// name,
+// author,
+// comment,
+// contains_sensitive_info,
+// reviewer,
+// status,
+// select_all,
+// zaak_filters,
 export type DestructionListUpdateData = {
   assignees?: DestructionListAssigneeUpdate[];
   add?: DestructionListItemUpdate[];
@@ -224,9 +238,14 @@ export async function destructionListQueueDestruction(uuid: string) {
   return null;
 }
 
+export type UpdateAssigneePostData = {
+  user: number;
+  role: ListRole;
+};
+
 export type DestructionListReassignData = {
   comment: string;
-  assignee: DestructionListAssigneeUpdate;
+  assignee: UpdateAssigneePostData;
 };
 
 /**
@@ -234,11 +253,16 @@ export type DestructionListReassignData = {
  * @param uuid
  * @param data
  */
-export async function reassignDestructionList(
+export async function updateAssigneeDestructionList(
   uuid: string,
   data: DestructionListReassignData,
 ) {
-  return request("POST", `/destruction-lists/${uuid}/reassign/`, {}, data);
+  return request(
+    "POST",
+    `/destruction-lists/${uuid}/update_assignee/`,
+    {},
+    data,
+  );
 }
 
 /**

--- a/frontend/src/lib/auth/permissions.ts
+++ b/frontend/src/lib/auth/permissions.ts
@@ -161,6 +161,7 @@ export const canReassignDestructionList: DestructionListPermissionCheck = (
     canReviewDestructionList(user, destructionList)) &&
   (destructionList.status === "new" ||
     destructionList.status === "changes_requested" ||
+    destructionList.status === "ready_for_archivist" ||
     destructionList.status === "ready_to_review");
 
 /**

--- a/frontend/src/lib/auth/permissions.ts
+++ b/frontend/src/lib/auth/permissions.ts
@@ -1,7 +1,6 @@
 import {
-  STATUSES_ELIGIBLE_FOR_CHANGING_ARCHIVIST,
-  STATUSES_ELIGIBLE_FOR_CHANGING_REVIEWER,
   STATUSES_ELIGIBLE_FOR_EDIT,
+  STATUS_ELIGIBLE_TO_REASSIGN_LIST,
 } from "../../pages/constants";
 import { User } from "../api/auth";
 import { DestructionList } from "../api/destructionLists";
@@ -161,28 +160,13 @@ export const canReassignDestructionList: DestructionListPermissionCheck = (
   user,
   destructionList,
 ) => {
-  let userHasCorrectRole = false;
-  let listHasCorrectStatus = false;
-  if (canStartDestructionList(user)) {
-    userHasCorrectRole = true;
-    listHasCorrectStatus =
-      STATUSES_ELIGIBLE_FOR_CHANGING_REVIEWER.includes(
-        destructionList.status,
-      ) ||
-      STATUSES_ELIGIBLE_FOR_CHANGING_ARCHIVIST.includes(destructionList.status);
-  } else if (user.role.canReviewDestruction) {
-    // Needed for the reviewer to be able to assign/reassign the co-reviewers
-    // We cannot use `canReviewDestruction` function, because it allows also
-    // archivists when the list is in state ready_for_archivist.
-    userHasCorrectRole = true;
-    listHasCorrectStatus = destructionList.status === "ready_to_review";
-  }
-
-  return userHasCorrectRole && listHasCorrectStatus;
+  return (
+    canStartDestructionList(user) &&
+    STATUS_ELIGIBLE_TO_REASSIGN_LIST.includes(destructionList.status)
+  );
 };
 
 /**
- * TODO: THIS CHECK NEETS TO BE EVALUATED ALONG WITH ITS PYTHON COUNTERPART
  * @param user
  * @param destructionList
  */

--- a/frontend/src/lib/auth/permissions.ts
+++ b/frontend/src/lib/auth/permissions.ts
@@ -1,4 +1,8 @@
-import { STATUSES_ELIGIBLE_FOR_EDIT } from "../../pages/constants";
+import {
+  STATUSES_ELIGIBLE_FOR_CHANGING_ARCHIVIST,
+  STATUSES_ELIGIBLE_FOR_CHANGING_REVIEWER,
+  STATUSES_ELIGIBLE_FOR_EDIT,
+} from "../../pages/constants";
 import { User } from "../api/auth";
 import { DestructionList } from "../api/destructionLists";
 
@@ -162,10 +166,10 @@ export const canReassignDestructionList: DestructionListPermissionCheck = (
   if (canStartDestructionList(user)) {
     userHasCorrectRole = true;
     listHasCorrectStatus =
-      destructionList.status === "new" ||
-      destructionList.status === "changes_requested" ||
-      destructionList.status === "ready_for_archivist" ||
-      destructionList.status === "ready_to_review";
+      STATUSES_ELIGIBLE_FOR_CHANGING_REVIEWER.includes(
+        destructionList.status,
+      ) ||
+      STATUSES_ELIGIBLE_FOR_CHANGING_ARCHIVIST.includes(destructionList.status);
   } else if (user.role.canReviewDestruction) {
     // Needed for the reviewer to be able to assign/reassign the co-reviewers
     // We cannot use `canReviewDestruction` function, because it allows also

--- a/frontend/src/lib/auth/permissions.ts
+++ b/frontend/src/lib/auth/permissions.ts
@@ -160,7 +160,31 @@ export const canReassignDestructionList: DestructionListPermissionCheck = (
   (canStartDestructionList(user) ||
     canReviewDestructionList(user, destructionList)) &&
   (destructionList.status === "new" ||
+    destructionList.status === "changes_requested" ||
     destructionList.status === "ready_to_review");
+
+/**
+ * TODO: THIS CHECK NEETS TO BE EVALUATED ALONG WITH ITS PYTHON COUNTERPART
+ * @param user
+ * @param destructionList
+ */
+export const canUpdateCoReviewers: DestructionListPermissionCheck = (
+  user,
+  destructionList,
+) => {
+  if (user.role.canStartDestruction) {
+    return (
+      destructionList.status === "new" ||
+      destructionList.status === "ready_to_review"
+    );
+  }
+
+  if (user.role.canReviewDestruction) {
+    return destructionList.status === "ready_to_review";
+  }
+
+  return false;
+};
 
 export const canDownloadReport: DestructionListPermissionCheck = (
   user,

--- a/frontend/src/pages/constants.tsx
+++ b/frontend/src/pages/constants.tsx
@@ -25,6 +25,12 @@ export const STATUSES_ELIGIBLE_FOR_CHANGING_REVIEWER = [
   "ready_to_review",
   "changes_requested",
 ];
+export const STATUS_ELIGIBLE_TO_REASSIGN_LIST = [
+  "new",
+  "ready_to_review",
+  "ready_for_archivist",
+  "changes_requested",
+];
 export const STATUSES_ELIGIBLE_FOR_CHANGING_ARCHIVIST = [
   "changes_requested",
   "ready_for_archivist",

--- a/frontend/src/pages/constants.tsx
+++ b/frontend/src/pages/constants.tsx
@@ -20,6 +20,15 @@ export const REVIEW_DECISION_LEVEL_MAPPING: Record<
 };
 
 export const STATUSES_ELIGIBLE_FOR_EDIT = ["new", "changes_requested"];
+export const STATUSES_ELIGIBLE_FOR_CHANGING_REVIEWER = [
+  "new",
+  "ready_to_review",
+  "changes_requested",
+];
+export const STATUSES_ELIGIBLE_FOR_CHANGING_ARCHIVIST = [
+  "changes_requested",
+  "ready_for_archivist",
+];
 
 export const STATUS_MAPPING: { [key in DestructionListStatus]: string } = {
   new: "nieuw",


### PR DESCRIPTION
Partially fixes #841 

**changes**

- Added a new endpoint to update one of the DestructionListAssignee related to a list. Compared to the `reassign` endpoint that already existed, this requires sending also which role the new assignee should have. This makes it possible to update a `DestructionListAssignee` that is not necessarily the `destruction_list.assignee`.

**Todo**

- [x] Backend: remove deprecated endpoint (we don't consider the API to be public).
- [x] Backend: test reassignment logic
- [x] Frontend: implement reassigning archivist