### PR TITLE
:zap: - perf: reduce network calls for related objects

### DIFF
--- a/frontend/src/components/RelatedObjectsSelection/RelatedObjectsSelectionModal.tsx
+++ b/frontend/src/components/RelatedObjectsSelection/RelatedObjectsSelectionModal.tsx
@@ -73,12 +73,14 @@ export const RelatedObjectsSelectionModal: React.FC<
         onClose={handleClose}
       >
         <Body>
-          <RelatedObjectsSelection
-            destructionList={destructionList}
-            destructionListItem={destructionListItemState}
-            user={user}
-            onChange={handleChange}
-          />
+          {modalOpenState && (
+            <RelatedObjectsSelection
+              destructionList={destructionList}
+              destructionListItem={destructionListItemState}
+              user={user}
+              onChange={handleChange}
+            />
+          )}
         </Body>
       </Modal>
     </>


### PR DESCRIPTION
The `RelatedObjectsSelection` triggers a network call to receive details about the related objects. This component was rendered for every row in a destruction list resulting in up to 100 network calls.